### PR TITLE
Compute correlations on GTEx v8 gene expression data

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -55,9 +55,15 @@ jobs:
         if: runner.os == 'Windows'
         env:
           PYTHONPATH: libs/
+        shell: cmd
         run: |
-          ${{ env.PY_ENV }}/python environment/scripts/setup_data.py --mode testing
-          ${{ env.PY_ENV }}/python -m pytest -v -rs tests
+          echo on
+          cd ${{ env.PY_ENV }}
+          call .\Scripts\activate.bat
+          .\Scripts\conda-unpack.exe
+          cd ..
+          python environment\scripts\setup_data.py --mode testing
+          pytest -v -rs tests
       - name: Setup data and run pytest (non-Windows systems)
         if: runner.os != 'Windows'
         shell: bash

--- a/libs/clustermatch/conf.py
+++ b/libs/clustermatch/conf.py
@@ -76,11 +76,15 @@ GTEX["SAMPLE_ATTRS_FILE"] = Path(
 GTEX["DATA_TPM_GCT_FILE"] = Path(
     GTEX["DATA_DIR"], "GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_tpm.gct.gz"
 ).resolve()
+GTEX["N_TISSUES"] = 54
 
 # Results
 GTEX["RESULTS_DIR"] = Path(RESULTS_DIR, "gtex_v8").resolve()
 
 GTEX["GENE_SELECTION_DIR"] = Path(GTEX["RESULTS_DIR"], "gene_selection").resolve()
+GTEX["SIMILARITY_MATRICES_DIR"] = Path(
+    GTEX["RESULTS_DIR"], "similarity_matrices"
+).resolve()
 
 
 if __name__ == "__main__":

--- a/libs/clustermatch/corr.py
+++ b/libs/clustermatch/corr.py
@@ -1,12 +1,26 @@
 """
 Functions to compute different correlation coefficients.
+
+All correlation functions in this module are expected to have the same input and output
+structure:
+
+ * The input is a pandas DataFrame with genes in rows (Ensembl IDs) and samples
+   columns. The values are gene expression data normalized with some technique,
+   but that should not be relevant for the correlation method.
+
+ * The output is a pandas DataFrame, a symmetric correlation matrix with genes
+   in rows and columns (Ensembl IDs), and the values are the correlation
+   coefficients. Diagonal values are expected to be ones.
 """
 import pandas as pd
 import numpy as np
 from sklearn.metrics import pairwise_distances
 
 
-def pearson(data):
+def pearson(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute the Pearson correlation coefficient.
+    """
     corr_mat = 1 - pairwise_distances(data.to_numpy(), metric="correlation", n_jobs=1)
 
     np.fill_diagonal(corr_mat, 1.0)
@@ -18,7 +32,10 @@ def pearson(data):
     )
 
 
-def spearman(data):
+def spearman(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute the Spearman correlation coefficient.
+    """
     # compute ranks
     data = data.rank(axis=1)
 

--- a/libs/clustermatch/corr.py
+++ b/libs/clustermatch/corr.py
@@ -21,3 +21,21 @@ def pearson(data):
         columns=data.index.copy(),
     )
 
+
+def spearman(data):
+    # compute ranks
+    data = data.rank(axis=1)
+
+    corr_mat = 1 - pairwise_distances(
+        data.to_numpy(),
+        metric="correlation",
+        n_jobs=1
+    )
+
+    np.fill_diagonal(corr_mat, 1.0)
+
+    return pd.DataFrame(
+        corr_mat,
+        index=data.index.copy(),
+        columns=data.index.copy(),
+    )

--- a/libs/clustermatch/corr.py
+++ b/libs/clustermatch/corr.py
@@ -7,11 +7,7 @@ from sklearn.metrics import pairwise_distances
 
 
 def pearson(data):
-    corr_mat = 1 - pairwise_distances(
-        data.to_numpy(),
-        metric="correlation",
-        n_jobs=1
-    )
+    corr_mat = 1 - pairwise_distances(data.to_numpy(), metric="correlation", n_jobs=1)
 
     np.fill_diagonal(corr_mat, 1.0)
 
@@ -26,11 +22,7 @@ def spearman(data):
     # compute ranks
     data = data.rank(axis=1)
 
-    corr_mat = 1 - pairwise_distances(
-        data.to_numpy(),
-        metric="correlation",
-        n_jobs=1
-    )
+    corr_mat = 1 - pairwise_distances(data.to_numpy(), metric="correlation", n_jobs=1)
 
     np.fill_diagonal(corr_mat, 1.0)
 

--- a/libs/clustermatch/corr.py
+++ b/libs/clustermatch/corr.py
@@ -1,0 +1,23 @@
+"""
+Functions to compute different correlation coefficients.
+"""
+import pandas as pd
+import numpy as np
+from sklearn.metrics import pairwise_distances
+
+
+def pearson(data):
+    corr_mat = 1 - pairwise_distances(
+        data.to_numpy(),
+        metric="correlation",
+        n_jobs=1
+    )
+
+    np.fill_diagonal(corr_mat, 1.0)
+
+    return pd.DataFrame(
+        corr_mat,
+        index=data.index.copy(),
+        columns=data.index.copy(),
+    )
+

--- a/nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb
+++ b/nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010569,
+     "end_time": "2021-09-01T16:47:37.867743",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.857174",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Description"
    ]
@@ -11,7 +20,16 @@
   {
    "cell_type": "markdown",
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00983,
+     "end_time": "2021-09-01T16:47:37.887716",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.877886",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "According to the settings specified below, this notebook:\n",
     " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
@@ -24,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.041319,
-     "end_time": "2021-08-28T03:41:34.325403",
+     "duration": 0.011029,
+     "end_time": "2021-09-01T16:47:37.909510",
      "exception": false,
-     "start_time": "2021-08-28T03:41:34.284084",
+     "start_time": "2021-09-01T16:47:37.898481",
      "status": "completed"
     },
     "tags": []
@@ -38,9 +56,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:37.939751Z",
+     "iopub.status.busy": "2021-09-01T16:47:37.939279Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.596826Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.596283Z"
+    },
+    "papermill": {
+     "duration": 0.676691,
+     "end_time": "2021-09-01T16:47:38.596938",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.920247",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -55,10 +88,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.041497,
-     "end_time": "2021-08-28T03:41:35.493961",
+     "duration": 0.010086,
+     "end_time": "2021-09-01T16:47:38.618172",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.452464",
+     "start_time": "2021-09-01T16:47:38.608086",
      "status": "completed"
     },
     "tags": []
@@ -69,9 +102,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.642531Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.642060Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.644359Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.643839Z"
+    },
+    "papermill": {
+     "duration": 0.015995,
+     "end_time": "2021-09-01T16:47:38.644456",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.628461",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "GENE_SELECTION_STRATEGY = \"var_raw\""
@@ -79,10 +127,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.674171Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.673689Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.678153Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.678515Z"
+    },
+    "papermill": {
+     "duration": 0.023325,
+     "end_time": "2021-09-01T16:47:38.678642",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.655317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'pearson'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CORRELATION_METHOD = pearson\n",
     "\n",
@@ -92,9 +165,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.704771Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.703647Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.707123Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.706651Z"
+    },
+    "papermill": {
+     "duration": 0.017081,
+     "end_time": "2021-09-01T16:47:38.707224",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.690143",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "PERFORMANCE_TEST_N_TOP_GENES = 500"
@@ -105,10 +193,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.041497,
-     "end_time": "2021-08-28T03:41:35.493961",
+     "duration": 0.010528,
+     "end_time": "2021-09-01T16:47:38.728618",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.452464",
+     "start_time": "2021-09-01T16:47:38.718090",
      "status": "completed"
     },
     "tags": []
@@ -119,19 +207,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.754919Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.754362Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.757280Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.756808Z"
+    },
     "papermill": {
-     "duration": 0.048722,
-     "end_time": "2021-08-28T03:41:35.845461",
+     "duration": 0.017698,
+     "end_time": "2021-09-01T16:47:38.757393",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.796739",
+     "start_time": "2021-09-01T16:47:38.739695",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/gene_selection')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "INPUT_DIR = conf.GTEX[\"GENE_SELECTION_DIR\"]\n",
     "display(INPUT_DIR)\n",
@@ -141,19 +245,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.784569Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.784089Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.787483Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.787893Z"
+    },
     "papermill": {
-     "duration": 0.048722,
-     "end_time": "2021-08-28T03:41:35.845461",
+     "duration": 0.019595,
+     "end_time": "2021-09-01T16:47:38.788047",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.796739",
+     "start_time": "2021-09-01T16:47:38.768452",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/similarity_matrices')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "OUTPUT_DIR = conf.GTEX[\"SIMILARITY_MATRICES_DIR\"]\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
@@ -165,10 +285,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.011293,
+     "end_time": "2021-09-01T16:47:38.811314",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:47:38.800021",
      "status": "completed"
     },
     "tags": []
@@ -179,19 +299,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.838609Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.838040Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.842917Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.842508Z"
+    },
     "papermill": {
-     "duration": 0.105096,
-     "end_time": "2021-08-28T03:45:12.900446",
+     "duration": 0.020006,
+     "end_time": "2021-09-01T16:47:38.843018",
      "exception": false,
-     "start_time": "2021-08-28T03:45:12.795350",
+     "start_time": "2021-09-01T16:47:38.823012",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "54"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_subcutaneous-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_visceral_omentum-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adrenal_gland-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_artery_aorta-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_artery_coronary-var_raw.pkl')]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "input_files = sorted(list(INPUT_DIR.glob(f\"*-{GENE_SELECTION_STRATEGY}.pkl\")))\n",
     "display(len(input_files))\n",
@@ -205,10 +354,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.013359,
+     "end_time": "2021-09-01T16:47:38.868909",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:47:38.855550",
      "status": "completed"
     },
     "tags": []
@@ -222,10 +371,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.013364,
+     "end_time": "2021-09-01T16:47:38.895699",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:47:38.882335",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +385,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.927338Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.926819Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.942305Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.941821Z"
+    },
+    "papermill": {
+     "duration": 0.032647,
+     "end_time": "2021-09-01T16:47:38.942409",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.909762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_subcutaneous-var_raw.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(input_files[0])\n",
     "test_data = pd.read_pickle(input_files[0])"
@@ -247,20 +421,344 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:38.972937Z",
+     "iopub.status.busy": "2021-09-01T16:47:38.972432Z",
+     "iopub.status.idle": "2021-09-01T16:47:38.975020Z",
+     "shell.execute_reply": "2021-09-01T16:47:38.974544Z"
+    },
+    "papermill": {
+     "duration": 0.019586,
+     "end_time": "2021-09-01T16:47:38.975115",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.955529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5000, 663)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:39.007157Z",
+     "iopub.status.busy": "2021-09-01T16:47:39.006665Z",
+     "iopub.status.idle": "2021-09-01T16:47:39.031622Z",
+     "shell.execute_reply": "2021-09-01T16:47:39.031205Z"
+    },
+    "papermill": {
+     "duration": 0.043426,
+     "end_time": "2021-09-01T16:47:39.031725",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.988299",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GTEX-1117F-0226-SM-5GZZ7</th>\n",
+       "      <th>GTEX-111CU-1826-SM-5GZYN</th>\n",
+       "      <th>GTEX-111FC-0226-SM-5N9B8</th>\n",
+       "      <th>GTEX-111VG-2326-SM-5N9BK</th>\n",
+       "      <th>GTEX-111YS-2426-SM-5GZZQ</th>\n",
+       "      <th>GTEX-1122O-2026-SM-9YFMG</th>\n",
+       "      <th>GTEX-1128S-2126-SM-5H12U</th>\n",
+       "      <th>GTEX-113IC-0226-SM-5HL5C</th>\n",
+       "      <th>GTEX-117YX-2226-SM-5EGJJ</th>\n",
+       "      <th>GTEX-11DXW-0326-SM-5H11W</th>\n",
+       "      <th>...</th>\n",
+       "      <th>GTEX-ZXES-2026-SM-5NQ6R</th>\n",
+       "      <th>GTEX-ZXG5-0226-SM-59HJI</th>\n",
+       "      <th>GTEX-ZYFC-0326-SM-5NQ7H</th>\n",
+       "      <th>GTEX-ZYFD-0226-SM-5NQ86</th>\n",
+       "      <th>GTEX-ZYT6-0326-SM-7LG5R</th>\n",
+       "      <th>GTEX-ZYVF-0226-SM-5GIEG</th>\n",
+       "      <th>GTEX-ZYW4-0226-SM-5E44M</th>\n",
+       "      <th>GTEX-ZYY3-0226-SM-5E45M</th>\n",
+       "      <th>GTEX-ZZ64-1626-SM-5E43W</th>\n",
+       "      <th>GTEX-ZZPU-2726-SM-5NQ8O</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <td>19890.0</td>\n",
+       "      <td>22670.0</td>\n",
+       "      <td>31580.0</td>\n",
+       "      <td>35680.0</td>\n",
+       "      <td>43170.0</td>\n",
+       "      <td>43400.0</td>\n",
+       "      <td>23850.0</td>\n",
+       "      <td>24240.0</td>\n",
+       "      <td>33190.0</td>\n",
+       "      <td>38500.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>38340.0</td>\n",
+       "      <td>28750.0</td>\n",
+       "      <td>45570.0</td>\n",
+       "      <td>62970.0</td>\n",
+       "      <td>37120.0</td>\n",
+       "      <td>25490.0</td>\n",
+       "      <td>38000.0</td>\n",
+       "      <td>38310.0</td>\n",
+       "      <td>28740.0</td>\n",
+       "      <td>37650.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <td>12400.0</td>\n",
+       "      <td>22230.0</td>\n",
+       "      <td>27330.0</td>\n",
+       "      <td>18780.0</td>\n",
+       "      <td>51290.0</td>\n",
+       "      <td>44250.0</td>\n",
+       "      <td>36100.0</td>\n",
+       "      <td>19370.0</td>\n",
+       "      <td>43040.0</td>\n",
+       "      <td>39050.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>39140.0</td>\n",
+       "      <td>19910.0</td>\n",
+       "      <td>34190.0</td>\n",
+       "      <td>22900.0</td>\n",
+       "      <td>26770.0</td>\n",
+       "      <td>22350.0</td>\n",
+       "      <td>20110.0</td>\n",
+       "      <td>36860.0</td>\n",
+       "      <td>35940.0</td>\n",
+       "      <td>29870.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "      <td>13880.0</td>\n",
+       "      <td>29860.0</td>\n",
+       "      <td>30250.0</td>\n",
+       "      <td>25050.0</td>\n",
+       "      <td>54710.0</td>\n",
+       "      <td>42500.0</td>\n",
+       "      <td>35230.0</td>\n",
+       "      <td>15870.0</td>\n",
+       "      <td>44020.0</td>\n",
+       "      <td>42060.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>47150.0</td>\n",
+       "      <td>27420.0</td>\n",
+       "      <td>24630.0</td>\n",
+       "      <td>34790.0</td>\n",
+       "      <td>29440.0</td>\n",
+       "      <td>28640.0</td>\n",
+       "      <td>26590.0</td>\n",
+       "      <td>40390.0</td>\n",
+       "      <td>38170.0</td>\n",
+       "      <td>35170.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198804.2</th>\n",
+       "      <td>10790.0</td>\n",
+       "      <td>11170.0</td>\n",
+       "      <td>21520.0</td>\n",
+       "      <td>20030.0</td>\n",
+       "      <td>31460.0</td>\n",
+       "      <td>32570.0</td>\n",
+       "      <td>21820.0</td>\n",
+       "      <td>18570.0</td>\n",
+       "      <td>20670.0</td>\n",
+       "      <td>20220.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>32630.0</td>\n",
+       "      <td>21210.0</td>\n",
+       "      <td>22990.0</td>\n",
+       "      <td>25390.0</td>\n",
+       "      <td>24380.0</td>\n",
+       "      <td>13940.0</td>\n",
+       "      <td>13980.0</td>\n",
+       "      <td>18500.0</td>\n",
+       "      <td>20760.0</td>\n",
+       "      <td>31970.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198888.2</th>\n",
+       "      <td>15870.0</td>\n",
+       "      <td>18770.0</td>\n",
+       "      <td>25570.0</td>\n",
+       "      <td>19760.0</td>\n",
+       "      <td>38440.0</td>\n",
+       "      <td>34070.0</td>\n",
+       "      <td>27410.0</td>\n",
+       "      <td>21560.0</td>\n",
+       "      <td>29330.0</td>\n",
+       "      <td>36640.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>37960.0</td>\n",
+       "      <td>24190.0</td>\n",
+       "      <td>39950.0</td>\n",
+       "      <td>31940.0</td>\n",
+       "      <td>25410.0</td>\n",
+       "      <td>15760.0</td>\n",
+       "      <td>26500.0</td>\n",
+       "      <td>28270.0</td>\n",
+       "      <td>30060.0</td>\n",
+       "      <td>31440.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 663 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   GTEX-1117F-0226-SM-5GZZ7  GTEX-111CU-1826-SM-5GZYN  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   19890.0                   22670.0   \n",
+       "ENSG00000198886.2                   12400.0                   22230.0   \n",
+       "ENSG00000198899.2                   13880.0                   29860.0   \n",
+       "ENSG00000198804.2                   10790.0                   11170.0   \n",
+       "ENSG00000198888.2                   15870.0                   18770.0   \n",
+       "\n",
+       "                   GTEX-111FC-0226-SM-5N9B8  GTEX-111VG-2326-SM-5N9BK  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   31580.0                   35680.0   \n",
+       "ENSG00000198886.2                   27330.0                   18780.0   \n",
+       "ENSG00000198899.2                   30250.0                   25050.0   \n",
+       "ENSG00000198804.2                   21520.0                   20030.0   \n",
+       "ENSG00000198888.2                   25570.0                   19760.0   \n",
+       "\n",
+       "                   GTEX-111YS-2426-SM-5GZZQ  GTEX-1122O-2026-SM-9YFMG  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   43170.0                   43400.0   \n",
+       "ENSG00000198886.2                   51290.0                   44250.0   \n",
+       "ENSG00000198899.2                   54710.0                   42500.0   \n",
+       "ENSG00000198804.2                   31460.0                   32570.0   \n",
+       "ENSG00000198888.2                   38440.0                   34070.0   \n",
+       "\n",
+       "                   GTEX-1128S-2126-SM-5H12U  GTEX-113IC-0226-SM-5HL5C  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   23850.0                   24240.0   \n",
+       "ENSG00000198886.2                   36100.0                   19370.0   \n",
+       "ENSG00000198899.2                   35230.0                   15870.0   \n",
+       "ENSG00000198804.2                   21820.0                   18570.0   \n",
+       "ENSG00000198888.2                   27410.0                   21560.0   \n",
+       "\n",
+       "                   GTEX-117YX-2226-SM-5EGJJ  GTEX-11DXW-0326-SM-5H11W  ...  \\\n",
+       "gene_ens_id                                                            ...   \n",
+       "ENSG00000198938.2                   33190.0                   38500.0  ...   \n",
+       "ENSG00000198886.2                   43040.0                   39050.0  ...   \n",
+       "ENSG00000198899.2                   44020.0                   42060.0  ...   \n",
+       "ENSG00000198804.2                   20670.0                   20220.0  ...   \n",
+       "ENSG00000198888.2                   29330.0                   36640.0  ...   \n",
+       "\n",
+       "                   GTEX-ZXES-2026-SM-5NQ6R  GTEX-ZXG5-0226-SM-59HJI  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  38340.0                  28750.0   \n",
+       "ENSG00000198886.2                  39140.0                  19910.0   \n",
+       "ENSG00000198899.2                  47150.0                  27420.0   \n",
+       "ENSG00000198804.2                  32630.0                  21210.0   \n",
+       "ENSG00000198888.2                  37960.0                  24190.0   \n",
+       "\n",
+       "                   GTEX-ZYFC-0326-SM-5NQ7H  GTEX-ZYFD-0226-SM-5NQ86  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  45570.0                  62970.0   \n",
+       "ENSG00000198886.2                  34190.0                  22900.0   \n",
+       "ENSG00000198899.2                  24630.0                  34790.0   \n",
+       "ENSG00000198804.2                  22990.0                  25390.0   \n",
+       "ENSG00000198888.2                  39950.0                  31940.0   \n",
+       "\n",
+       "                   GTEX-ZYT6-0326-SM-7LG5R  GTEX-ZYVF-0226-SM-5GIEG  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  37120.0                  25490.0   \n",
+       "ENSG00000198886.2                  26770.0                  22350.0   \n",
+       "ENSG00000198899.2                  29440.0                  28640.0   \n",
+       "ENSG00000198804.2                  24380.0                  13940.0   \n",
+       "ENSG00000198888.2                  25410.0                  15760.0   \n",
+       "\n",
+       "                   GTEX-ZYW4-0226-SM-5E44M  GTEX-ZYY3-0226-SM-5E45M  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  38000.0                  38310.0   \n",
+       "ENSG00000198886.2                  20110.0                  36860.0   \n",
+       "ENSG00000198899.2                  26590.0                  40390.0   \n",
+       "ENSG00000198804.2                  13980.0                  18500.0   \n",
+       "ENSG00000198888.2                  26500.0                  28270.0   \n",
+       "\n",
+       "                   GTEX-ZZ64-1626-SM-5E43W  GTEX-ZZPU-2726-SM-5NQ8O  \n",
+       "gene_ens_id                                                          \n",
+       "ENSG00000198938.2                  28740.0                  37650.0  \n",
+       "ENSG00000198886.2                  35940.0                  29870.0  \n",
+       "ENSG00000198899.2                  38170.0                  35170.0  \n",
+       "ENSG00000198804.2                  20760.0                  31970.0  \n",
+       "ENSG00000198888.2                  30060.0                  31440.0  \n",
+       "\n",
+       "[5 rows x 663 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.head()"
    ]
@@ -268,17 +766,117 @@
   {
    "cell_type": "markdown",
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.015078,
+     "end_time": "2021-09-01T16:47:39.061229",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.046151",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:39.095483Z",
+     "iopub.status.busy": "2021-09-01T16:47:39.094917Z",
+     "iopub.status.idle": "2021-09-01T16:47:39.102316Z",
+     "shell.execute_reply": "2021-09-01T16:47:39.102734Z"
+    },
+    "papermill": {
+     "duration": 0.027224,
+     "end_time": "2021-09-01T16:47:39.102873",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.075649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 3)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.519992</td>\n",
+       "      <td>0.639912</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <td>0.519992</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.833569</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "      <td>0.639912</td>\n",
+       "      <td>0.833569</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "gene_ens_id        ENSG00000198938.2  ENSG00000198886.2  ENSG00000198899.2\n",
+       "gene_ens_id                                                               \n",
+       "ENSG00000198938.2           1.000000           0.519992           0.639912\n",
+       "ENSG00000198886.2           0.519992           1.000000           0.833569\n",
+       "ENSG00000198899.2           0.639912           0.833569           1.000000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
     "\n",
@@ -288,10 +886,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:39.138743Z",
+     "iopub.status.busy": "2021-09-01T16:47:39.138211Z",
+     "iopub.status.idle": "2021-09-01T16:47:43.686416Z",
+     "shell.execute_reply": "2021-09-01T16:47:43.685938Z"
+    },
+    "papermill": {
+     "duration": 4.568251,
+     "end_time": "2021-09-01T16:47:43.686520",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.118269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "56.2 ms ± 928 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])"
    ]
@@ -301,10 +922,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.015392,
+     "end_time": "2021-09-01T16:47:43.716801",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:47:43.701409",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +936,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "1237ae45-d4fc-4074-bfc7-a1de75aeea48",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:47:43.752227Z",
+     "iopub.status.busy": "2021-09-01T16:47:43.751610Z",
+     "iopub.status.idle": "2021-09-01T16:50:25.222182Z",
+     "shell.execute_reply": "2021-09-01T16:50:25.221737Z"
+    },
+    "papermill": {
+     "duration": 161.490684,
+     "end_time": "2021-09-01T16:50:25.222303",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:43.731619",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "gtex_v8_data_whole_blood-var_raw: 100%|█████████████████████████████| 54/54 [02:41<00:00,  2.99s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "pbar = tqdm(input_files, ncols=100)\n",
     "\n",
@@ -340,7 +984,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.035801,
+     "end_time": "2021-09-01T16:50:25.296220",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:25.260419",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -365,6 +1018,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 168.556635,
+   "end_time": "2021-09-01T16:50:25.542183",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb",
+   "output_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-09-01T16:47:36.985548",
+   "version": "2.3.3"
   }
  },
  "nbformat": 4,

--- a/nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb
+++ b/nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb
@@ -1,0 +1,372 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
+   "metadata": {},
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
+   "metadata": {},
+   "source": [
+    "According to the settings specified below, this notebook:\n",
+    " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
+    " 2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and\n",
+    " 3. computes the correlation matrix across all the genes using the correlation coefficient specified."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041319,
+     "end_time": "2021-08-28T03:41:34.325403",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:34.284084",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from clustermatch import conf\n",
+    "from clustermatch.corr import pearson"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041497,
+     "end_time": "2021-08-28T03:41:35.493961",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.452464",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56ff94d3-a230-4028-a71d-518ac109209b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GENE_SELECTION_STRATEGY = \"var_raw\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CORRELATION_METHOD = pearson\n",
+    "\n",
+    "method_name = CORRELATION_METHOD.__name__\n",
+    "display(method_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERFORMANCE_TEST_N_TOP_GENES = 500"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041497,
+     "end_time": "2021-08-28T03:41:35.493961",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.452464",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.048722,
+     "end_time": "2021-08-28T03:41:35.845461",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.796739",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "INPUT_DIR = conf.GTEX[\"GENE_SELECTION_DIR\"]\n",
+    "display(INPUT_DIR)\n",
+    "\n",
+    "assert INPUT_DIR.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.048722,
+     "end_time": "2021-08-28T03:41:35.845461",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.796739",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = conf.GTEX[\"SIMILARITY_MATRICES_DIR\"]\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "display(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Data loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.105096,
+     "end_time": "2021-08-28T03:45:12.900446",
+     "exception": false,
+     "start_time": "2021-08-28T03:45:12.795350",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_files = sorted(list(INPUT_DIR.glob(f\"*-{GENE_SELECTION_STRATEGY}.pkl\")))\n",
+    "display(len(input_files))\n",
+    "\n",
+    "assert len(input_files) == conf.GTEX[\"N_TISSUES\"], len(input_files)\n",
+    "display(input_files[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Compute similarity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Performance test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(input_files[0])\n",
+    "test_data = pd.read_pickle(input_files[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5903f3f5-791e-4f03-9d79-600102933d04",
+   "metadata": {},
+   "source": [
+    "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
+    "\n",
+    "display(_tmp.shape)\n",
+    "display(_tmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2f7184-c0da-438c-94f5-002912793636",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1237ae45-d4fc-4074-bfc7-a1de75aeea48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pbar = tqdm(input_files, ncols=100)\n",
+    "\n",
+    "for tissue_data_file in pbar:\n",
+    "    pbar.set_description(tissue_data_file.stem)\n",
+    "\n",
+    "    # read\n",
+    "    data = pd.read_pickle(tissue_data_file)\n",
+    "\n",
+    "    # compute correlations\n",
+    "    data_corrs = CORRELATION_METHOD(data)\n",
+    "\n",
+    "    # save\n",
+    "    output_filename = f\"{tissue_data_file.stem}-{method_name}.pkl\"\n",
+    "    data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.ipynb
+++ b/nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.039348,
+     "end_time": "2021-09-01T16:50:28.619472",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:28.580124",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Description"
    ]
@@ -11,7 +20,16 @@
   {
    "cell_type": "markdown",
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010185,
+     "end_time": "2021-09-01T16:50:28.645667",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:28.635482",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "According to the settings specified below, this notebook:\n",
     " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
@@ -24,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.041319,
-     "end_time": "2021-08-28T03:41:34.325403",
+     "duration": 0.008914,
+     "end_time": "2021-09-01T16:50:28.663566",
      "exception": false,
-     "start_time": "2021-08-28T03:41:34.284084",
+     "start_time": "2021-09-01T16:50:28.654652",
      "status": "completed"
     },
     "tags": []
@@ -38,9 +56,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:28.689278Z",
+     "iopub.status.busy": "2021-09-01T16:50:28.688822Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.289435Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.288957Z"
+    },
+    "papermill": {
+     "duration": 0.617024,
+     "end_time": "2021-09-01T16:50:29.289547",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:28.672523",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -55,10 +88,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.041497,
-     "end_time": "2021-08-28T03:41:35.493961",
+     "duration": 0.009085,
+     "end_time": "2021-09-01T16:50:29.308132",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.452464",
+     "start_time": "2021-09-01T16:50:29.299047",
      "status": "completed"
     },
     "tags": []
@@ -69,9 +102,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.330338Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.329869Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.331542Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.331921Z"
+    },
+    "papermill": {
+     "duration": 0.014813,
+     "end_time": "2021-09-01T16:50:29.332048",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.317235",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "GENE_SELECTION_STRATEGY = \"var_raw\""
@@ -79,10 +127,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.359264Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.358300Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.363351Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.362970Z"
+    },
+    "papermill": {
+     "duration": 0.021593,
+     "end_time": "2021-09-01T16:50:29.363450",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.341857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'spearman'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CORRELATION_METHOD = spearman\n",
     "\n",
@@ -92,9 +165,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.387502Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.387052Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.388979Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.388611Z"
+    },
+    "papermill": {
+     "duration": 0.014951,
+     "end_time": "2021-09-01T16:50:29.389075",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.374124",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "PERFORMANCE_TEST_N_TOP_GENES = 500"
@@ -105,10 +193,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.041497,
-     "end_time": "2021-08-28T03:41:35.493961",
+     "duration": 0.009847,
+     "end_time": "2021-09-01T16:50:29.409160",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.452464",
+     "start_time": "2021-09-01T16:50:29.399313",
      "status": "completed"
     },
     "tags": []
@@ -119,19 +207,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.432619Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.432102Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.434992Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.434622Z"
+    },
     "papermill": {
-     "duration": 0.048722,
-     "end_time": "2021-08-28T03:41:35.845461",
+     "duration": 0.016011,
+     "end_time": "2021-09-01T16:50:29.435086",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.796739",
+     "start_time": "2021-09-01T16:50:29.419075",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/gene_selection')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "INPUT_DIR = conf.GTEX[\"GENE_SELECTION_DIR\"]\n",
     "display(INPUT_DIR)\n",
@@ -141,19 +245,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.458956Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.458418Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.461365Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.460918Z"
+    },
     "papermill": {
-     "duration": 0.048722,
-     "end_time": "2021-08-28T03:41:35.845461",
+     "duration": 0.016244,
+     "end_time": "2021-09-01T16:50:29.461457",
      "exception": false,
-     "start_time": "2021-08-28T03:41:35.796739",
+     "start_time": "2021-09-01T16:50:29.445213",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/similarity_matrices')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "OUTPUT_DIR = conf.GTEX[\"SIMILARITY_MATRICES_DIR\"]\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
@@ -165,10 +285,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.010571,
+     "end_time": "2021-09-01T16:50:29.482915",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:50:29.472344",
      "status": "completed"
     },
     "tags": []
@@ -179,19 +299,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.507392Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.506908Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.511899Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.512268Z"
+    },
     "papermill": {
-     "duration": 0.105096,
-     "end_time": "2021-08-28T03:45:12.900446",
+     "duration": 0.018945,
+     "end_time": "2021-09-01T16:50:29.512377",
      "exception": false,
-     "start_time": "2021-08-28T03:45:12.795350",
+     "start_time": "2021-09-01T16:50:29.493432",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "54"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_subcutaneous-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_visceral_omentum-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adrenal_gland-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_artery_aorta-var_raw.pkl'),\n",
+       " PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_artery_coronary-var_raw.pkl')]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "input_files = sorted(list(INPUT_DIR.glob(f\"*-{GENE_SELECTION_STRATEGY}.pkl\")))\n",
     "display(len(input_files))\n",
@@ -205,10 +354,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.010902,
+     "end_time": "2021-09-01T16:50:29.534433",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:50:29.523531",
      "status": "completed"
     },
     "tags": []
@@ -222,10 +371,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.010649,
+     "end_time": "2021-09-01T16:50:29.556032",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:50:29.545383",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +385,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.581847Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.581325Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.595641Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.595215Z"
+    },
+    "papermill": {
+     "duration": 0.028707,
+     "end_time": "2021-09-01T16:50:29.595744",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.567037",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/gtex_v8/gene_selection/gtex_v8_data_adipose_subcutaneous-var_raw.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(input_files[0])\n",
     "test_data = pd.read_pickle(input_files[0])"
@@ -247,20 +421,344 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.624078Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.623590Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.626541Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.626133Z"
+    },
+    "papermill": {
+     "duration": 0.018338,
+     "end_time": "2021-09-01T16:50:29.626638",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.608300",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5000, 663)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.672306Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.664025Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.675425Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.674960Z"
+    },
+    "papermill": {
+     "duration": 0.036518,
+     "end_time": "2021-09-01T16:50:29.675521",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.639003",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GTEX-1117F-0226-SM-5GZZ7</th>\n",
+       "      <th>GTEX-111CU-1826-SM-5GZYN</th>\n",
+       "      <th>GTEX-111FC-0226-SM-5N9B8</th>\n",
+       "      <th>GTEX-111VG-2326-SM-5N9BK</th>\n",
+       "      <th>GTEX-111YS-2426-SM-5GZZQ</th>\n",
+       "      <th>GTEX-1122O-2026-SM-9YFMG</th>\n",
+       "      <th>GTEX-1128S-2126-SM-5H12U</th>\n",
+       "      <th>GTEX-113IC-0226-SM-5HL5C</th>\n",
+       "      <th>GTEX-117YX-2226-SM-5EGJJ</th>\n",
+       "      <th>GTEX-11DXW-0326-SM-5H11W</th>\n",
+       "      <th>...</th>\n",
+       "      <th>GTEX-ZXES-2026-SM-5NQ6R</th>\n",
+       "      <th>GTEX-ZXG5-0226-SM-59HJI</th>\n",
+       "      <th>GTEX-ZYFC-0326-SM-5NQ7H</th>\n",
+       "      <th>GTEX-ZYFD-0226-SM-5NQ86</th>\n",
+       "      <th>GTEX-ZYT6-0326-SM-7LG5R</th>\n",
+       "      <th>GTEX-ZYVF-0226-SM-5GIEG</th>\n",
+       "      <th>GTEX-ZYW4-0226-SM-5E44M</th>\n",
+       "      <th>GTEX-ZYY3-0226-SM-5E45M</th>\n",
+       "      <th>GTEX-ZZ64-1626-SM-5E43W</th>\n",
+       "      <th>GTEX-ZZPU-2726-SM-5NQ8O</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <td>19890.0</td>\n",
+       "      <td>22670.0</td>\n",
+       "      <td>31580.0</td>\n",
+       "      <td>35680.0</td>\n",
+       "      <td>43170.0</td>\n",
+       "      <td>43400.0</td>\n",
+       "      <td>23850.0</td>\n",
+       "      <td>24240.0</td>\n",
+       "      <td>33190.0</td>\n",
+       "      <td>38500.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>38340.0</td>\n",
+       "      <td>28750.0</td>\n",
+       "      <td>45570.0</td>\n",
+       "      <td>62970.0</td>\n",
+       "      <td>37120.0</td>\n",
+       "      <td>25490.0</td>\n",
+       "      <td>38000.0</td>\n",
+       "      <td>38310.0</td>\n",
+       "      <td>28740.0</td>\n",
+       "      <td>37650.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <td>12400.0</td>\n",
+       "      <td>22230.0</td>\n",
+       "      <td>27330.0</td>\n",
+       "      <td>18780.0</td>\n",
+       "      <td>51290.0</td>\n",
+       "      <td>44250.0</td>\n",
+       "      <td>36100.0</td>\n",
+       "      <td>19370.0</td>\n",
+       "      <td>43040.0</td>\n",
+       "      <td>39050.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>39140.0</td>\n",
+       "      <td>19910.0</td>\n",
+       "      <td>34190.0</td>\n",
+       "      <td>22900.0</td>\n",
+       "      <td>26770.0</td>\n",
+       "      <td>22350.0</td>\n",
+       "      <td>20110.0</td>\n",
+       "      <td>36860.0</td>\n",
+       "      <td>35940.0</td>\n",
+       "      <td>29870.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "      <td>13880.0</td>\n",
+       "      <td>29860.0</td>\n",
+       "      <td>30250.0</td>\n",
+       "      <td>25050.0</td>\n",
+       "      <td>54710.0</td>\n",
+       "      <td>42500.0</td>\n",
+       "      <td>35230.0</td>\n",
+       "      <td>15870.0</td>\n",
+       "      <td>44020.0</td>\n",
+       "      <td>42060.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>47150.0</td>\n",
+       "      <td>27420.0</td>\n",
+       "      <td>24630.0</td>\n",
+       "      <td>34790.0</td>\n",
+       "      <td>29440.0</td>\n",
+       "      <td>28640.0</td>\n",
+       "      <td>26590.0</td>\n",
+       "      <td>40390.0</td>\n",
+       "      <td>38170.0</td>\n",
+       "      <td>35170.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198804.2</th>\n",
+       "      <td>10790.0</td>\n",
+       "      <td>11170.0</td>\n",
+       "      <td>21520.0</td>\n",
+       "      <td>20030.0</td>\n",
+       "      <td>31460.0</td>\n",
+       "      <td>32570.0</td>\n",
+       "      <td>21820.0</td>\n",
+       "      <td>18570.0</td>\n",
+       "      <td>20670.0</td>\n",
+       "      <td>20220.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>32630.0</td>\n",
+       "      <td>21210.0</td>\n",
+       "      <td>22990.0</td>\n",
+       "      <td>25390.0</td>\n",
+       "      <td>24380.0</td>\n",
+       "      <td>13940.0</td>\n",
+       "      <td>13980.0</td>\n",
+       "      <td>18500.0</td>\n",
+       "      <td>20760.0</td>\n",
+       "      <td>31970.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198888.2</th>\n",
+       "      <td>15870.0</td>\n",
+       "      <td>18770.0</td>\n",
+       "      <td>25570.0</td>\n",
+       "      <td>19760.0</td>\n",
+       "      <td>38440.0</td>\n",
+       "      <td>34070.0</td>\n",
+       "      <td>27410.0</td>\n",
+       "      <td>21560.0</td>\n",
+       "      <td>29330.0</td>\n",
+       "      <td>36640.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>37960.0</td>\n",
+       "      <td>24190.0</td>\n",
+       "      <td>39950.0</td>\n",
+       "      <td>31940.0</td>\n",
+       "      <td>25410.0</td>\n",
+       "      <td>15760.0</td>\n",
+       "      <td>26500.0</td>\n",
+       "      <td>28270.0</td>\n",
+       "      <td>30060.0</td>\n",
+       "      <td>31440.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 663 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   GTEX-1117F-0226-SM-5GZZ7  GTEX-111CU-1826-SM-5GZYN  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   19890.0                   22670.0   \n",
+       "ENSG00000198886.2                   12400.0                   22230.0   \n",
+       "ENSG00000198899.2                   13880.0                   29860.0   \n",
+       "ENSG00000198804.2                   10790.0                   11170.0   \n",
+       "ENSG00000198888.2                   15870.0                   18770.0   \n",
+       "\n",
+       "                   GTEX-111FC-0226-SM-5N9B8  GTEX-111VG-2326-SM-5N9BK  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   31580.0                   35680.0   \n",
+       "ENSG00000198886.2                   27330.0                   18780.0   \n",
+       "ENSG00000198899.2                   30250.0                   25050.0   \n",
+       "ENSG00000198804.2                   21520.0                   20030.0   \n",
+       "ENSG00000198888.2                   25570.0                   19760.0   \n",
+       "\n",
+       "                   GTEX-111YS-2426-SM-5GZZQ  GTEX-1122O-2026-SM-9YFMG  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   43170.0                   43400.0   \n",
+       "ENSG00000198886.2                   51290.0                   44250.0   \n",
+       "ENSG00000198899.2                   54710.0                   42500.0   \n",
+       "ENSG00000198804.2                   31460.0                   32570.0   \n",
+       "ENSG00000198888.2                   38440.0                   34070.0   \n",
+       "\n",
+       "                   GTEX-1128S-2126-SM-5H12U  GTEX-113IC-0226-SM-5HL5C  \\\n",
+       "gene_ens_id                                                             \n",
+       "ENSG00000198938.2                   23850.0                   24240.0   \n",
+       "ENSG00000198886.2                   36100.0                   19370.0   \n",
+       "ENSG00000198899.2                   35230.0                   15870.0   \n",
+       "ENSG00000198804.2                   21820.0                   18570.0   \n",
+       "ENSG00000198888.2                   27410.0                   21560.0   \n",
+       "\n",
+       "                   GTEX-117YX-2226-SM-5EGJJ  GTEX-11DXW-0326-SM-5H11W  ...  \\\n",
+       "gene_ens_id                                                            ...   \n",
+       "ENSG00000198938.2                   33190.0                   38500.0  ...   \n",
+       "ENSG00000198886.2                   43040.0                   39050.0  ...   \n",
+       "ENSG00000198899.2                   44020.0                   42060.0  ...   \n",
+       "ENSG00000198804.2                   20670.0                   20220.0  ...   \n",
+       "ENSG00000198888.2                   29330.0                   36640.0  ...   \n",
+       "\n",
+       "                   GTEX-ZXES-2026-SM-5NQ6R  GTEX-ZXG5-0226-SM-59HJI  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  38340.0                  28750.0   \n",
+       "ENSG00000198886.2                  39140.0                  19910.0   \n",
+       "ENSG00000198899.2                  47150.0                  27420.0   \n",
+       "ENSG00000198804.2                  32630.0                  21210.0   \n",
+       "ENSG00000198888.2                  37960.0                  24190.0   \n",
+       "\n",
+       "                   GTEX-ZYFC-0326-SM-5NQ7H  GTEX-ZYFD-0226-SM-5NQ86  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  45570.0                  62970.0   \n",
+       "ENSG00000198886.2                  34190.0                  22900.0   \n",
+       "ENSG00000198899.2                  24630.0                  34790.0   \n",
+       "ENSG00000198804.2                  22990.0                  25390.0   \n",
+       "ENSG00000198888.2                  39950.0                  31940.0   \n",
+       "\n",
+       "                   GTEX-ZYT6-0326-SM-7LG5R  GTEX-ZYVF-0226-SM-5GIEG  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  37120.0                  25490.0   \n",
+       "ENSG00000198886.2                  26770.0                  22350.0   \n",
+       "ENSG00000198899.2                  29440.0                  28640.0   \n",
+       "ENSG00000198804.2                  24380.0                  13940.0   \n",
+       "ENSG00000198888.2                  25410.0                  15760.0   \n",
+       "\n",
+       "                   GTEX-ZYW4-0226-SM-5E44M  GTEX-ZYY3-0226-SM-5E45M  \\\n",
+       "gene_ens_id                                                           \n",
+       "ENSG00000198938.2                  38000.0                  38310.0   \n",
+       "ENSG00000198886.2                  20110.0                  36860.0   \n",
+       "ENSG00000198899.2                  26590.0                  40390.0   \n",
+       "ENSG00000198804.2                  13980.0                  18500.0   \n",
+       "ENSG00000198888.2                  26500.0                  28270.0   \n",
+       "\n",
+       "                   GTEX-ZZ64-1626-SM-5E43W  GTEX-ZZPU-2726-SM-5NQ8O  \n",
+       "gene_ens_id                                                          \n",
+       "ENSG00000198938.2                  28740.0                  37650.0  \n",
+       "ENSG00000198886.2                  35940.0                  29870.0  \n",
+       "ENSG00000198899.2                  38170.0                  35170.0  \n",
+       "ENSG00000198804.2                  20760.0                  31970.0  \n",
+       "ENSG00000198888.2                  30060.0                  31440.0  \n",
+       "\n",
+       "[5 rows x 663 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.head()"
    ]
@@ -268,17 +766,117 @@
   {
    "cell_type": "markdown",
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011919,
+     "end_time": "2021-09-01T16:50:29.700316",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.688397",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.729249Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.728341Z",
+     "iopub.status.idle": "2021-09-01T16:50:29.736207Z",
+     "shell.execute_reply": "2021-09-01T16:50:29.736564Z"
+    },
+    "papermill": {
+     "duration": 0.024287,
+     "end_time": "2021-09-01T16:50:29.736675",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.712388",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 3)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gene_ens_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198938.2</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.477131</td>\n",
+       "      <td>0.607149</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198886.2</th>\n",
+       "      <td>0.477131</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.821754</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ENSG00000198899.2</th>\n",
+       "      <td>0.607149</td>\n",
+       "      <td>0.821754</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "gene_ens_id        ENSG00000198938.2  ENSG00000198886.2  ENSG00000198899.2\n",
+       "gene_ens_id                                                               \n",
+       "ENSG00000198938.2           1.000000           0.477131           0.607149\n",
+       "ENSG00000198886.2           0.477131           1.000000           0.821754\n",
+       "ENSG00000198899.2           0.607149           0.821754           1.000000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
     "\n",
@@ -288,10 +886,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:29.766744Z",
+     "iopub.status.busy": "2021-09-01T16:50:29.766292Z",
+     "iopub.status.idle": "2021-09-01T16:50:35.313712Z",
+     "shell.execute_reply": "2021-09-01T16:50:35.313261Z"
+    },
+    "papermill": {
+     "duration": 5.564106,
+     "end_time": "2021-09-01T16:50:35.313806",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:29.749700",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "68.5 ms ± 571 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])"
    ]
@@ -301,10 +922,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.025129,
-     "end_time": "2021-08-27T13:12:58.917286",
+     "duration": 0.012903,
+     "end_time": "2021-09-01T16:50:35.340064",
      "exception": false,
-     "start_time": "2021-08-27T13:12:58.892157",
+     "start_time": "2021-09-01T16:50:35.327161",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +936,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "1237ae45-d4fc-4074-bfc7-a1de75aeea48",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-01T16:50:35.371338Z",
+     "iopub.status.busy": "2021-09-01T16:50:35.370834Z",
+     "iopub.status.idle": "2021-09-01T16:53:20.598433Z",
+     "shell.execute_reply": "2021-09-01T16:53:20.597945Z"
+    },
+    "papermill": {
+     "duration": 165.245344,
+     "end_time": "2021-09-01T16:53:20.598540",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:35.353196",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "gtex_v8_data_whole_blood-var_raw: 100%|█████████████████████████████| 54/54 [02:45<00:00,  3.06s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "pbar = tqdm(input_files, ncols=100)\n",
     "\n",
@@ -340,7 +984,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.034492,
+     "end_time": "2021-09-01T16:53:20.668945",
+     "exception": false,
+     "start_time": "2021-09-01T16:53:20.634453",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -365,6 +1018,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 173.18631,
+   "end_time": "2021-09-01T16:53:20.910949",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.ipynb",
+   "output_path": "nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-09-01T16:50:27.724639",
+   "version": "2.3.3"
   }
  },
  "nbformat": 4,

--- a/nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.ipynb
+++ b/nbs/10_compute_correlations/05_gtex_v8/06-gtex-spearman.ipynb
@@ -1,0 +1,372 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
+   "metadata": {},
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
+   "metadata": {},
+   "source": [
+    "According to the settings specified below, this notebook:\n",
+    " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
+    " 2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and\n",
+    " 3. computes the correlation matrix across all the genes using the correlation coefficient specified."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041319,
+     "end_time": "2021-08-28T03:41:34.325403",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:34.284084",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from clustermatch import conf\n",
+    "from clustermatch.corr import spearman"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041497,
+     "end_time": "2021-08-28T03:41:35.493961",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.452464",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56ff94d3-a230-4028-a71d-518ac109209b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GENE_SELECTION_STRATEGY = \"var_raw\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CORRELATION_METHOD = spearman\n",
+    "\n",
+    "method_name = CORRELATION_METHOD.__name__\n",
+    "display(method_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERFORMANCE_TEST_N_TOP_GENES = 500"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041497,
+     "end_time": "2021-08-28T03:41:35.493961",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.452464",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.048722,
+     "end_time": "2021-08-28T03:41:35.845461",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.796739",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "INPUT_DIR = conf.GTEX[\"GENE_SELECTION_DIR\"]\n",
+    "display(INPUT_DIR)\n",
+    "\n",
+    "assert INPUT_DIR.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.048722,
+     "end_time": "2021-08-28T03:41:35.845461",
+     "exception": false,
+     "start_time": "2021-08-28T03:41:35.796739",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = conf.GTEX[\"SIMILARITY_MATRICES_DIR\"]\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "display(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Data loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.105096,
+     "end_time": "2021-08-28T03:45:12.900446",
+     "exception": false,
+     "start_time": "2021-08-28T03:45:12.795350",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_files = sorted(list(INPUT_DIR.glob(f\"*-{GENE_SELECTION_STRATEGY}.pkl\")))\n",
+    "display(len(input_files))\n",
+    "\n",
+    "assert len(input_files) == conf.GTEX[\"N_TISSUES\"], len(input_files)\n",
+    "display(input_files[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Compute similarity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Performance test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(input_files[0])\n",
+    "test_data = pd.read_pickle(input_files[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5903f3f5-791e-4f03-9d79-600102933d04",
+   "metadata": {},
+   "source": [
+    "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
+    "\n",
+    "display(_tmp.shape)\n",
+    "display(_tmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2f7184-c0da-438c-94f5-002912793636",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025129,
+     "end_time": "2021-08-27T13:12:58.917286",
+     "exception": false,
+     "start_time": "2021-08-27T13:12:58.892157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1237ae45-d4fc-4074-bfc7-a1de75aeea48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pbar = tqdm(input_files, ncols=100)\n",
+    "\n",
+    "for tissue_data_file in pbar:\n",
+    "    pbar.set_description(tissue_data_file.stem)\n",
+    "\n",
+    "    # read\n",
+    "    data = pd.read_pickle(tissue_data_file)\n",
+    "\n",
+    "    # compute correlations\n",
+    "    data_corrs = CORRELATION_METHOD(data)\n",
+    "\n",
+    "    # save\n",
+    "    output_filename = f\"{tissue_data_file.stem}-{method_name}.pkl\"\n",
+    "    data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/10_compute_correlations/05_gtex_v8/py/05-gtex-pearson.py
+++ b/nbs/10_compute_correlations/05_gtex_v8/py/05-gtex-pearson.py
@@ -13,10 +13,10 @@
 #     name: python3
 # ---
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # # Description
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # According to the settings specified below, this notebook:
 #  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
 #  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
@@ -25,7 +25,7 @@
 # %% [markdown] tags=[]
 # # Modules
 
-# %%
+# %% tags=[]
 import pandas as pd
 from tqdm import tqdm
 
@@ -35,16 +35,16 @@ from clustermatch.corr import pearson
 # %% [markdown] tags=[]
 # # Settings
 
-# %%
+# %% tags=[]
 GENE_SELECTION_STRATEGY = "var_raw"
 
-# %%
+# %% tags=[]
 CORRELATION_METHOD = pearson
 
 method_name = CORRELATION_METHOD.__name__
 display(method_name)
 
-# %%
+# %% tags=[]
 PERFORMANCE_TEST_N_TOP_GENES = 500
 
 # %% [markdown] tags=[]
@@ -77,32 +77,32 @@ display(input_files[:5])
 # %% [markdown] tags=[]
 # ## Performance test
 
-# %%
+# %% tags=[]
 display(input_files[0])
 test_data = pd.read_pickle(input_files[0])
 
-# %%
+# %% tags=[]
 test_data.shape
 
-# %%
+# %% tags=[]
 test_data.head()
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
 
-# %%
+# %% tags=[]
 _tmp = CORRELATION_METHOD(test_data.iloc[:3])
 
 display(_tmp.shape)
 display(_tmp)
 
-# %%
+# %% tags=[]
 # %timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])
 
 # %% [markdown] tags=[]
 # ## Run
 
-# %%
+# %% tags=[]
 pbar = tqdm(input_files, ncols=100)
 
 for tissue_data_file in pbar:
@@ -118,4 +118,4 @@ for tissue_data_file in pbar:
     output_filename = f"{tissue_data_file.stem}-{method_name}.pkl"
     data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)
 
-# %%
+# %% tags=[]

--- a/nbs/10_compute_correlations/05_gtex_v8/py/05-gtex-pearson.py
+++ b/nbs/10_compute_correlations/05_gtex_v8/py/05-gtex-pearson.py
@@ -1,0 +1,121 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Description
+
+# %% [markdown]
+# According to the settings specified below, this notebook:
+#  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
+#  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
+#  3. computes the correlation matrix across all the genes using the correlation coefficient specified.
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %%
+import pandas as pd
+from tqdm import tqdm
+
+from clustermatch import conf
+from clustermatch.corr import pearson
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %%
+GENE_SELECTION_STRATEGY = "var_raw"
+
+# %%
+CORRELATION_METHOD = pearson
+
+method_name = CORRELATION_METHOD.__name__
+display(method_name)
+
+# %%
+PERFORMANCE_TEST_N_TOP_GENES = 500
+
+# %% [markdown] tags=[]
+# # Paths
+
+# %% tags=[]
+INPUT_DIR = conf.GTEX["GENE_SELECTION_DIR"]
+display(INPUT_DIR)
+
+assert INPUT_DIR.exists()
+
+# %% tags=[]
+OUTPUT_DIR = conf.GTEX["SIMILARITY_MATRICES_DIR"]
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+display(OUTPUT_DIR)
+
+# %% [markdown] tags=[]
+# # Data loading
+
+# %% tags=[]
+input_files = sorted(list(INPUT_DIR.glob(f"*-{GENE_SELECTION_STRATEGY}.pkl")))
+display(len(input_files))
+
+assert len(input_files) == conf.GTEX["N_TISSUES"], len(input_files)
+display(input_files[:5])
+
+# %% [markdown] tags=[]
+# # Compute similarity
+
+# %% [markdown] tags=[]
+# ## Performance test
+
+# %%
+display(input_files[0])
+test_data = pd.read_pickle(input_files[0])
+
+# %%
+test_data.shape
+
+# %%
+test_data.head()
+
+# %% [markdown]
+# This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
+
+# %%
+_tmp = CORRELATION_METHOD(test_data.iloc[:3])
+
+display(_tmp.shape)
+display(_tmp)
+
+# %%
+# %timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])
+
+# %% [markdown] tags=[]
+# ## Run
+
+# %%
+pbar = tqdm(input_files, ncols=100)
+
+for tissue_data_file in pbar:
+    pbar.set_description(tissue_data_file.stem)
+
+    # read
+    data = pd.read_pickle(tissue_data_file)
+
+    # compute correlations
+    data_corrs = CORRELATION_METHOD(data)
+
+    # save
+    output_filename = f"{tissue_data_file.stem}-{method_name}.pkl"
+    data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)
+
+# %%

--- a/nbs/10_compute_correlations/05_gtex_v8/py/06-gtex-spearman.py
+++ b/nbs/10_compute_correlations/05_gtex_v8/py/06-gtex-spearman.py
@@ -1,0 +1,121 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Description
+
+# %% [markdown]
+# According to the settings specified below, this notebook:
+#  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
+#  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
+#  3. computes the correlation matrix across all the genes using the correlation coefficient specified.
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %%
+import pandas as pd
+from tqdm import tqdm
+
+from clustermatch import conf
+from clustermatch.corr import spearman
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %%
+GENE_SELECTION_STRATEGY = "var_raw"
+
+# %%
+CORRELATION_METHOD = spearman
+
+method_name = CORRELATION_METHOD.__name__
+display(method_name)
+
+# %%
+PERFORMANCE_TEST_N_TOP_GENES = 500
+
+# %% [markdown] tags=[]
+# # Paths
+
+# %% tags=[]
+INPUT_DIR = conf.GTEX["GENE_SELECTION_DIR"]
+display(INPUT_DIR)
+
+assert INPUT_DIR.exists()
+
+# %% tags=[]
+OUTPUT_DIR = conf.GTEX["SIMILARITY_MATRICES_DIR"]
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+display(OUTPUT_DIR)
+
+# %% [markdown] tags=[]
+# # Data loading
+
+# %% tags=[]
+input_files = sorted(list(INPUT_DIR.glob(f"*-{GENE_SELECTION_STRATEGY}.pkl")))
+display(len(input_files))
+
+assert len(input_files) == conf.GTEX["N_TISSUES"], len(input_files)
+display(input_files[:5])
+
+# %% [markdown] tags=[]
+# # Compute similarity
+
+# %% [markdown] tags=[]
+# ## Performance test
+
+# %%
+display(input_files[0])
+test_data = pd.read_pickle(input_files[0])
+
+# %%
+test_data.shape
+
+# %%
+test_data.head()
+
+# %% [markdown]
+# This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
+
+# %%
+_tmp = CORRELATION_METHOD(test_data.iloc[:3])
+
+display(_tmp.shape)
+display(_tmp)
+
+# %%
+# %timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])
+
+# %% [markdown] tags=[]
+# ## Run
+
+# %%
+pbar = tqdm(input_files, ncols=100)
+
+for tissue_data_file in pbar:
+    pbar.set_description(tissue_data_file.stem)
+
+    # read
+    data = pd.read_pickle(tissue_data_file)
+
+    # compute correlations
+    data_corrs = CORRELATION_METHOD(data)
+
+    # save
+    output_filename = f"{tissue_data_file.stem}-{method_name}.pkl"
+    data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)
+
+# %%

--- a/nbs/10_compute_correlations/05_gtex_v8/py/06-gtex-spearman.py
+++ b/nbs/10_compute_correlations/05_gtex_v8/py/06-gtex-spearman.py
@@ -13,10 +13,10 @@
 #     name: python3
 # ---
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # # Description
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # According to the settings specified below, this notebook:
 #  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
 #  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
@@ -25,7 +25,7 @@
 # %% [markdown] tags=[]
 # # Modules
 
-# %%
+# %% tags=[]
 import pandas as pd
 from tqdm import tqdm
 
@@ -35,16 +35,16 @@ from clustermatch.corr import spearman
 # %% [markdown] tags=[]
 # # Settings
 
-# %%
+# %% tags=[]
 GENE_SELECTION_STRATEGY = "var_raw"
 
-# %%
+# %% tags=[]
 CORRELATION_METHOD = spearman
 
 method_name = CORRELATION_METHOD.__name__
 display(method_name)
 
-# %%
+# %% tags=[]
 PERFORMANCE_TEST_N_TOP_GENES = 500
 
 # %% [markdown] tags=[]
@@ -77,32 +77,32 @@ display(input_files[:5])
 # %% [markdown] tags=[]
 # ## Performance test
 
-# %%
+# %% tags=[]
 display(input_files[0])
 test_data = pd.read_pickle(input_files[0])
 
-# %%
+# %% tags=[]
 test_data.shape
 
-# %%
+# %% tags=[]
 test_data.head()
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
 
-# %%
+# %% tags=[]
 _tmp = CORRELATION_METHOD(test_data.iloc[:3])
 
 display(_tmp.shape)
 display(_tmp)
 
-# %%
+# %% tags=[]
 # %timeit CORRELATION_METHOD(test_data.iloc[:PERFORMANCE_TEST_N_TOP_GENES])
 
 # %% [markdown] tags=[]
 # ## Run
 
-# %%
+# %% tags=[]
 pbar = tqdm(input_files, ncols=100)
 
 for tissue_data_file in pbar:
@@ -118,4 +118,4 @@ for tissue_data_file in pbar:
     output_filename = f"{tissue_data_file.stem}-{method_name}.pkl"
     data_corrs.to_pickle(path=OUTPUT_DIR / output_filename)
 
-# %%
+# %% tags=[]

--- a/scripts/rsync.sh
+++ b/scripts/rsync.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Intended for internal use only, with very personalized settings.
+#
+# This script runs rsync with some common parameters to sync with a remote
+# machine. For instance, it checks files' hashes instead of timestamp, and
+# excludes some huge files not needed.
+
+GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+LOCAL_DIR="${GIT_ROOT_DIR}/base/"
+
+REMOTE_DIR="/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/*"
+
+rsync \
+        -chavzP \
+        --stats \
+        --exclude 'GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_tpm.gct.gz' \
+        --exclude 'GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt' \
+        --exclude 'recount_data_prep_PLIER.*' \
+        --exclude 'recount2_PLIER_data.zip' \
+        pcgreene:${REMOTE_DIR} \
+        ${LOCAL_DIR}
+

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -1,0 +1,73 @@
+"""
+Tests the corr.py module.
+"""
+import numpy as np
+import pandas as pd
+
+from clustermatch import corr
+
+
+def _get_random_data(n_genes, n_samples, random_state=0):
+    np.random.seed(random_state)
+
+    # simulate data with a real structure of genes and samples
+    random_data = np.random.rand(n_genes, n_samples)
+    return pd.DataFrame(
+        data=random_data,
+        index=[f"ENSG00000123456.{i}" for i in range(random_data.shape[0])],
+        columns=[f"Sample-Number-{i}" for i in range(random_data.shape[1])],
+    )
+
+
+def _run_basic_checks(corr_method, random_state=0):
+    n_genes = 10
+    n_samples = 100
+    random_data = _get_random_data(n_genes, n_samples, random_state)
+
+    # run
+    corr_mat = corr_method(random_data)
+    assert corr_mat is not None
+
+    # shape
+    assert hasattr(corr_mat, "shape")
+    assert corr_mat.shape == (n_genes, n_genes)
+
+    # row/columns names are genes
+    assert hasattr(corr_mat, "index")
+    assert list(corr_mat.index) == list(random_data.index)
+
+    assert hasattr(corr_mat, "columns")
+    assert list(corr_mat.columns) == list(random_data.index)
+
+    assert hasattr(corr_mat, "columns")
+
+    # dtype
+    assert np.issubdtype(corr_mat.to_numpy().dtype, np.number)
+
+    # diagonal has ones
+    assert np.array_equal(np.diag(corr_mat), np.ones(n_genes))
+
+    # matrix is symmetric
+    assert corr_mat.equals(corr_mat.T)
+
+    return random_data, corr_mat
+
+
+def test_corr_pearson():
+    # run basic tests first
+    data, corr_mat = _run_basic_checks(corr.pearson)
+
+    corr_values = pd.Series(corr_mat.to_numpy().flatten())
+
+    # check ranges
+    assert corr_values.max() <= 1.0
+    assert corr_values.min() >= -1.0
+    assert np.sign(corr_values.max()) != np.sign(corr_values.min())
+
+    # calculate pearson with a different method and check if it is the same
+    numpy_pearson = np.corrcoef(data.to_numpy())
+
+    assert np.allclose(
+        numpy_pearson,
+        corr_mat.to_numpy(),
+    )

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -86,6 +86,7 @@ def test_corr_spearman():
 
     # calculate pearson with a different method and check if it is the same
     from scipy.stats import spearmanr
+
     scipy_spearman_mat = spearmanr(data.to_numpy(), axis=1)[0]
 
     assert np.allclose(

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -65,9 +65,30 @@ def test_corr_pearson():
     assert np.sign(corr_values.max()) != np.sign(corr_values.min())
 
     # calculate pearson with a different method and check if it is the same
-    numpy_pearson = np.corrcoef(data.to_numpy())
+    numpy_pearson_mat = np.corrcoef(data.to_numpy())
 
     assert np.allclose(
-        numpy_pearson,
+        numpy_pearson_mat,
+        corr_mat.to_numpy(),
+    )
+
+
+def test_corr_spearman():
+    # run basic tests first
+    data, corr_mat = _run_basic_checks(corr.spearman)
+
+    corr_values = pd.Series(corr_mat.to_numpy().flatten())
+
+    # check ranges
+    assert corr_values.max() <= 1.0
+    assert corr_values.min() >= -1.0
+    assert np.sign(corr_values.max()) != np.sign(corr_values.min())
+
+    # calculate pearson with a different method and check if it is the same
+    from scipy.stats import spearmanr
+    scipy_spearman_mat = spearmanr(data.to_numpy(), axis=1)[0]
+
+    assert np.allclose(
+        scipy_spearman_mat,
         corr_mat.to_numpy(),
     )

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -109,7 +109,7 @@ def test_corr_pearson_manual():
     test_data = pd.DataFrame(np.array([x, y]))
 
     num = (x - x.mean()) @ (y - y.mean())
-    dem=np.sqrt(np.sum((x-x.mean())**2) * np.sum((y-y.mean())**2))
+    dem = np.sqrt(np.sum((x - x.mean()) ** 2) * np.sum((y - y.mean()) ** 2))
     expected_corr = num / dem
     assert expected_corr == 0.5879747322073337
 
@@ -156,7 +156,7 @@ def test_corr_spearman_manual():
     y = order.argsort()
 
     num = (x - x.mean()) @ (y - y.mean())
-    dem=np.sqrt(np.sum((x-x.mean())**2) * np.sum((y-y.mean())**2))
+    dem = np.sqrt(np.sum((x - x.mean()) ** 2) * np.sum((y - y.mean()) ** 2))
     expected_corr = num / dem
     assert round(expected_corr, 5) == 0.2
 

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -70,8 +70,6 @@ def _run_basic_checks(corr_method, random_state=0) -> tuple[pd.DataFrame, pd.Dat
     assert hasattr(corr_mat, "columns")
     assert list(corr_mat.columns) == list(random_data.index)
 
-    assert hasattr(corr_mat, "columns")
-
     # dtype
     assert np.issubdtype(corr_mat.to_numpy().dtype, np.number)
 

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -7,11 +7,28 @@ import pandas as pd
 from clustermatch import corr
 
 
-def _get_random_data(n_genes, n_samples, random_state=0):
+def _get_random_data(n_genes: int, n_samples: int, random_state=0) -> pd.DataFrame:
+    """
+    Simulates with random data a gene expression data matrix in the same format
+    of real datasets.
+
+    Args:
+        n_genes: number of genes (rows) to be generated.
+        n_samples: number of samples (columns) to be generated.
+        random_state: random seed for np.random.seed.
+
+    Returns:
+        A pandas DataFrame with random numerical values generated with
+        np.random.rand. The index will have simulated gene Ensembl IDs with the
+        following format: ENSG00000123456.{i}, where {i} is the index of the
+        gene (starting from zero to n_genes - 1). The columns will have
+        simulated sample IDs with the following format: Sample-Number-{i}.
+    """
     np.random.seed(random_state)
 
     # simulate data with a real structure of genes and samples
     random_data = np.random.rand(n_genes, n_samples)
+
     return pd.DataFrame(
         data=random_data,
         index=[f"ENSG00000123456.{i}" for i in range(random_data.shape[0])],
@@ -19,7 +36,21 @@ def _get_random_data(n_genes, n_samples, random_state=0):
     )
 
 
-def _run_basic_checks(corr_method, random_state=0):
+def _run_basic_checks(corr_method, random_state=0) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Performs basic checks on the output of a correlation method.
+
+    Args:
+        corr_method: a function that computes the correlations among genes. This
+            function receives the data as the only arguments, which has the same
+            format returned by function _get_random_data. It must return a
+            correlation matrix as with the same format specified in the corr.py
+            module (description at the top of file).
+        random_state: passed to the _get_random_data function.
+
+    Returns:
+        A tuple with the random data generated and the correlation matrix.
+    """
     n_genes = 10
     n_samples = 100
     random_data = _get_random_data(n_genes, n_samples, random_state)

--- a/tests/test_corr.py
+++ b/tests/test_corr.py
@@ -102,6 +102,24 @@ def test_corr_pearson():
     )
 
 
+def test_corr_pearson_manual():
+    # add basic check with manual calculation of the correlation
+    x = np.array([0, 1, 2, 3])
+    y = np.array([0, -1, -3, 8])
+    test_data = pd.DataFrame(np.array([x, y]))
+
+    num = (x - x.mean()) @ (y - y.mean())
+    dem=np.sqrt(np.sum((x-x.mean())**2) * np.sum((y-y.mean())**2))
+    expected_corr = num / dem
+    assert expected_corr == 0.5879747322073337
+
+    test_result = corr.pearson(test_data)
+    assert test_result.iloc[0, 0] == 1.0
+    assert test_result.iloc[0, 1] == expected_corr
+    assert test_result.iloc[1, 0] == expected_corr
+    assert test_result.iloc[1, 1] == 1.0
+
+
 def test_corr_spearman():
     # run basic tests first
     data, corr_mat = _run_basic_checks(corr.spearman)
@@ -122,3 +140,28 @@ def test_corr_spearman():
         scipy_spearman_mat,
         corr_mat.to_numpy(),
     )
+
+
+def test_corr_spearman_manual():
+    # add basic check with manual calculation of the correlation
+    x = np.array([0, 1, 2, 3])
+    y = np.array([0, -1, -3, 8])
+    test_data = pd.DataFrame(np.array([x, y]))
+
+    # get ranks
+    order = x.argsort()
+    x = order.argsort()
+
+    order = y.argsort()
+    y = order.argsort()
+
+    num = (x - x.mean()) @ (y - y.mean())
+    dem=np.sqrt(np.sum((x-x.mean())**2) * np.sum((y-y.mean())**2))
+    expected_corr = num / dem
+    assert round(expected_corr, 5) == 0.2
+
+    test_result = corr.spearman(test_data)
+    assert test_result.iloc[0, 0] == 1.0
+    assert test_result.iloc[0, 1].round(5) == expected_corr
+    assert test_result.iloc[1, 0].round(5) == expected_corr
+    assert test_result.iloc[1, 1] == 1.0


### PR DESCRIPTION
This PR adds code to compute the Pearson and Spearman correlations in GTEx v8 expression data across 54 tissues. It uses the input data that was preprocessed in [another PR](https://github.com/greenelab/clustermatch-gene-expr/pull/4).

The main files that need review are:
* `libs/clustermatch/corr.py` (and `test_corr.py`): it contains functions to compute correlations.
* `.../05-gtex-pearson.ipynb`: computes the Pearson correlation.
* `.../06-gtex-spearman.ipynb`: computes the Spearman correlation.
* `.github/workflows/pytest.yaml`: it now properly supports a Windows runner in Github Actions.

The rest of the files are auxiliary scripts not directly used for the analyses but, of course, you are welcomed to take a look.