### PR TITLE
Add code to process recount2 data and compute correlation matrices

### DIFF
--- a/environment/scripts/setup_data.py
+++ b/environment/scripts/setup_data.py
@@ -39,7 +39,7 @@ def get_file_from_zip(
     """
     from clustermatch.utils import md5_matches
 
-    logger.info(f"Checking if output file: {output_file}")
+    logger.info(f"Checking output file: {output_file}")
 
     # do not download file again if it exists and MD5 matches the expected one
     if output_file.exists() and md5_matches(output_file_md5, output_file):

--- a/environment/scripts/setup_data.py
+++ b/environment/scripts/setup_data.py
@@ -18,24 +18,24 @@ DATA_IN_TESTING_MODE_ONLY = {}
 
 
 def get_file_from_zip(
-    zip_file_url,
-    zip_file_path,
-    zip_file_md5,
-    zip_internal_filename,
-    output_file,
-    output_file_md5,
+    zip_file_url: str,
+    zip_file_path: str,
+    zip_file_md5: str,
+    zip_internal_filename: Path,
+    output_file: Path,
+    output_file_md5: str,
 ):
     """
-    This method downloads a zip file and extracts a particular file inside
-    it.
-    TODO: finish documentation of arguments
+    It downloads a zip file and extracts a particular file inside it to a specified
+    location.
+
     Args:
-        zip_file_url:
-        zip_file_path:
-        zip_file_md5:
-        zip_internal_filename:
-        output_file:
-        output_file_md5:
+        zip_file_url: the URL of the zip file that contains the file of interest.
+        zip_file_path: path where the zip file will be saved.
+        zip_file_md5: MD5 hash of the zip file.
+        zip_internal_filename: filepath inside of the zip file that needs to be extracted.
+        output_file: output filepath where zip_internal_filename will be saved.
+        output_file_md5: MD5 hash of the file inside the zip file.
     """
     from clustermatch.utils import md5_matches
 
@@ -47,8 +47,6 @@ def get_file_from_zip(
         return
 
     # download zip file
-    parent_dir = output_file.parent
-
     curl(
         zip_file_url,
         zip_file_path,
@@ -60,15 +58,13 @@ def get_file_from_zip(
     logger.info(f"Extracting {zip_internal_filename}")
     import zipfile
 
+    parent_dir = output_file.parent
     with zipfile.ZipFile(zip_file_path, "r") as z:
         z.extract(str(zip_internal_filename), path=parent_dir)
 
     # rename file
     Path(parent_dir, zip_internal_filename).rename(output_file)
     Path(parent_dir, zip_internal_filename.parent).rmdir()
-
-    # delete zip file
-    # zip_file_path.unlink()
 
 
 def download_gtex_v8_sample_attributes(**kwargs):

--- a/environment/scripts/setup_data.py
+++ b/environment/scripts/setup_data.py
@@ -39,6 +39,8 @@ def get_file_from_zip(
     """
     from clustermatch.utils import md5_matches
 
+    logger.info(f"Checking if output file: {output_file}")
+
     # do not download file again if it exists and MD5 matches the expected one
     if output_file.exists() and md5_matches(output_file_md5, output_file):
         logger.info(f"File already downloaded: {output_file}")

--- a/libs/clustermatch/conf.py
+++ b/libs/clustermatch/conf.py
@@ -102,6 +102,13 @@ RECOUNT2["DATA_FILE"] = Path(
     RECOUNT2["DATA_DIR"], "recount_data_prep_PLIER.pkl"
 ).resolve()
 
+# Results
+RECOUNT2["RESULTS_DIR"] = Path(RESULTS_DIR, "recount2").resolve()
+
+RECOUNT2["SIMILARITY_MATRICES_DIR"] = Path(
+    RECOUNT2["RESULTS_DIR"], "similarity_matrices"
+).resolve()
+
 
 if __name__ == "__main__":
     # if this script is run, then it exports the configuration as environment

--- a/libs/clustermatch/conf.py
+++ b/libs/clustermatch/conf.py
@@ -87,6 +87,22 @@ GTEX["SIMILARITY_MATRICES_DIR"] = Path(
 ).resolve()
 
 
+#
+# recount2 (from MultiPLIER)
+#
+RECOUNT2 = {}
+
+# Input data
+RECOUNT2["DATA_DIR"] = Path(DATA_DIR, "recount2").resolve()
+
+RECOUNT2["DATA_RDS_FILE"] = Path(
+    RECOUNT2["DATA_DIR"], "recount_data_prep_PLIER.RDS"
+).resolve()
+RECOUNT2["DATA_FILE"] = Path(
+    RECOUNT2["DATA_DIR"], "recount_data_prep_PLIER.pkl"
+).resolve()
+
+
 if __name__ == "__main__":
     # if this script is run, then it exports the configuration as environment
     # variables (for bash/R, etc)

--- a/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
+++ b/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
@@ -78,8 +78,6 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "from pathlib import Path\n",
-    "from shutil import copyfile\n",
     "\n",
     "import pandas as pd\n",
     "import rpy2.robjects as ro\n",

--- a/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
+++ b/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
@@ -2,12 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "9525f35c",
    "metadata": {
     "papermill": {
-     "duration": 0.028312,
-     "end_time": "2021-07-31T02:44:43.844573",
+     "duration": 0.024615,
+     "end_time": "2021-09-09T14:38:17.306169",
      "exception": false,
-     "start_time": "2021-07-31T02:44:43.816261",
+     "start_time": "2021-09-09T14:38:17.281554",
      "status": "completed"
     },
     "tags": []
@@ -18,12 +19,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7c7a21cf",
    "metadata": {
     "papermill": {
-     "duration": 0.021036,
-     "end_time": "2021-07-31T02:44:43.888392",
+     "duration": 0.023991,
+     "end_time": "2021-09-09T14:38:17.354538",
      "exception": false,
-     "start_time": "2021-07-31T02:44:43.867356",
+     "start_time": "2021-09-09T14:38:17.330547",
      "status": "completed"
     },
     "tags": []
@@ -36,12 +38,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aed5444b",
    "metadata": {
     "papermill": {
-     "duration": 0.021103,
-     "end_time": "2021-07-31T02:44:43.930581",
+     "duration": 0.024372,
+     "end_time": "2021-09-09T14:38:17.402987",
      "exception": false,
-     "start_time": "2021-07-31T02:44:43.909478",
+     "start_time": "2021-09-09T14:38:17.378615",
      "status": "completed"
     },
     "tags": []
@@ -52,13 +55,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
+   "id": "96058a2b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:17.458918Z",
+     "iopub.status.busy": "2021-09-09T14:38:17.458444Z",
+     "iopub.status.idle": "2021-09-09T14:38:17.988931Z",
+     "shell.execute_reply": "2021-09-09T14:38:17.988312Z"
+    },
     "papermill": {
-     "duration": 0.437138,
-     "end_time": "2021-07-31T02:44:44.444679",
+     "duration": 0.561987,
+     "end_time": "2021-09-09T14:38:17.989039",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.007541",
+     "start_time": "2021-09-09T14:38:17.427052",
      "status": "completed"
     },
     "tags": []
@@ -79,13 +89,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
+   "id": "7939727e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:18.040895Z",
+     "iopub.status.busy": "2021-09-09T14:38:18.039263Z",
+     "iopub.status.idle": "2021-09-09T14:38:18.043938Z",
+     "shell.execute_reply": "2021-09-09T14:38:18.043438Z"
+    },
     "papermill": {
-     "duration": 0.032406,
-     "end_time": "2021-07-31T02:44:44.498981",
+     "duration": 0.030914,
+     "end_time": "2021-09-09T14:38:18.044037",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.466575",
+     "start_time": "2021-09-09T14:38:18.013123",
      "status": "completed"
     },
     "tags": []
@@ -97,13 +114,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
+   "id": "c04feb24",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:18.096596Z",
+     "iopub.status.busy": "2021-09-09T14:38:18.096108Z",
+     "iopub.status.idle": "2021-09-09T14:38:18.098382Z",
+     "shell.execute_reply": "2021-09-09T14:38:18.098007Z"
+    },
     "papermill": {
-     "duration": 0.031723,
-     "end_time": "2021-07-31T02:44:44.553118",
+     "duration": 0.029993,
+     "end_time": "2021-09-09T14:38:18.098484",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.521395",
+     "start_time": "2021-09-09T14:38:18.068491",
      "status": "completed"
     },
     "tags": []
@@ -115,12 +139,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eae41b9b",
    "metadata": {
     "papermill": {
-     "duration": 0.021057,
-     "end_time": "2021-07-31T02:44:44.595949",
+     "duration": 0.023971,
+     "end_time": "2021-09-09T14:38:18.146918",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.574892",
+     "start_time": "2021-09-09T14:38:18.122947",
      "status": "completed"
     },
     "tags": []
@@ -131,13 +156,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
+   "id": "5aa92721",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:18.207990Z",
+     "iopub.status.busy": "2021-09-09T14:38:18.206814Z",
+     "iopub.status.idle": "2021-09-09T14:38:18.210987Z",
+     "shell.execute_reply": "2021-09-09T14:38:18.210592Z"
+    },
     "papermill": {
-     "duration": 0.033301,
-     "end_time": "2021-07-31T02:44:44.717183",
+     "duration": 0.03836,
+     "end_time": "2021-09-09T14:38:18.211085",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.683882",
+     "start_time": "2021-09-09T14:38:18.172725",
      "status": "completed"
     },
     "tags": []
@@ -146,7 +178,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2')"
+       "PosixPath('/opt/data/data/recount2')"
       ]
      },
      "metadata": {},
@@ -161,12 +193,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f8df9aac",
    "metadata": {
     "papermill": {
-     "duration": 0.021698,
-     "end_time": "2021-07-31T02:44:44.761260",
+     "duration": 0.024418,
+     "end_time": "2021-09-09T14:38:18.260259",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.739562",
+     "start_time": "2021-09-09T14:38:18.235841",
      "status": "completed"
     },
     "tags": []
@@ -177,13 +210,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
+   "id": "f7dc63ca",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:18.314200Z",
+     "iopub.status.busy": "2021-09-09T14:38:18.313675Z",
+     "iopub.status.idle": "2021-09-09T14:38:18.315861Z",
+     "shell.execute_reply": "2021-09-09T14:38:18.316227Z"
+    },
     "papermill": {
-     "duration": 0.034664,
-     "end_time": "2021-07-31T02:44:44.817090",
+     "duration": 0.030881,
+     "end_time": "2021-09-09T14:38:18.316352",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.782426",
+     "start_time": "2021-09-09T14:38:18.285471",
      "status": "completed"
     },
     "tags": []
@@ -192,7 +232,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_data_prep_PLIER.RDS')"
+       "PosixPath('/opt/data/data/recount2/recount_data_prep_PLIER.RDS')"
       ]
      },
      "metadata": {},
@@ -209,13 +249,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
+   "id": "0760310e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:18.370796Z",
+     "iopub.status.busy": "2021-09-09T14:38:18.370322Z",
+     "iopub.status.idle": "2021-09-09T14:38:31.202530Z",
+     "shell.execute_reply": "2021-09-09T14:38:31.202101Z"
+    },
     "papermill": {
-     "duration": 12.550085,
-     "end_time": "2021-07-31T02:44:57.393996",
+     "duration": 12.860508,
+     "end_time": "2021-09-09T14:38:31.202630",
      "exception": false,
-     "start_time": "2021-07-31T02:44:44.843911",
+     "start_time": "2021-09-09T14:38:18.342122",
      "status": "completed"
     },
     "tags": []
@@ -227,12 +274,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9f899380",
    "metadata": {
     "papermill": {
-     "duration": 0.021193,
-     "end_time": "2021-07-31T02:44:57.438041",
+     "duration": 0.024865,
+     "end_time": "2021-09-09T14:38:31.252752",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.416848",
+     "start_time": "2021-09-09T14:38:31.227887",
      "status": "completed"
     },
     "tags": []
@@ -243,12 +291,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b544a961",
    "metadata": {
     "papermill": {
-     "duration": 0.021193,
-     "end_time": "2021-07-31T02:44:57.438041",
+     "duration": 0.024919,
+     "end_time": "2021-09-09T14:38:31.302392",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.416848",
+     "start_time": "2021-09-09T14:38:31.277473",
      "status": "completed"
     },
     "tags": []
@@ -259,13 +308,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
+   "id": "e8c2ca39",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:31.356059Z",
+     "iopub.status.busy": "2021-09-09T14:38:31.354618Z",
+     "iopub.status.idle": "2021-09-09T14:38:31.358310Z",
+     "shell.execute_reply": "2021-09-09T14:38:31.357907Z"
+    },
     "papermill": {
-     "duration": 0.031948,
-     "end_time": "2021-07-31T02:44:57.491486",
+     "duration": 0.031065,
+     "end_time": "2021-09-09T14:38:31.358409",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.459538",
+     "start_time": "2021-09-09T14:38:31.327344",
      "status": "completed"
     },
     "tags": []
@@ -277,13 +333,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
+   "id": "e4b8ee3f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:31.412885Z",
+     "iopub.status.busy": "2021-09-09T14:38:31.411291Z",
+     "iopub.status.idle": "2021-09-09T14:38:31.421677Z",
+     "shell.execute_reply": "2021-09-09T14:38:31.421210Z"
+    },
     "papermill": {
-     "duration": 0.036813,
-     "end_time": "2021-07-31T02:44:57.550537",
+     "duration": 0.037502,
+     "end_time": "2021-09-09T14:38:31.421776",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.513724",
+     "start_time": "2021-09-09T14:38:31.384274",
      "status": "completed"
     },
     "tags": []
@@ -609,45 +672,45 @@
        "    "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.DataFrame object at 0x7f1a94576540> [RTYPES.VECSXP]\n",
+       "<rpy2.robjects.vectors.DataFrame object at 0x7f17a27981c0> [RTYPES.VECSXP]\n",
        "R classes: ('data.frame',)\n",
        "[FloatSexp..., FloatSexp..., FloatSexp..., FloatSexp..., ..., FloatSexp..., FloatSexp..., FloatSexp..., FloatSexp...]\n",
        "  SRP000599.SRR013549: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d615140> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f17a27807c0> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.312500, -0.328279, -0.286319, -0.536646, ..., -0.142179, -0.349886, -0.085582, -0.567112]\n",
        "  SRP000599.SRR013550: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d660040> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cb01ec0> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.142384, -0.349886, -0.085582, -0.569146]\n",
        "  SRP000599.SRR013551: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b2c0> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab8780> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.140314, -0.349886, -0.085582, -0.569146]\n",
        "  SRP000599.SRR013552: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b280> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab8880> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.142384, -0.349886, -0.085582, -0.569146]\n",
        "...\n",
        "  SRP000599.SRR013554: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b880> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab85c0> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.309599, -0.326375, -0.286859, 1.507099, ..., -0.142304, -0.149655, 1.280258, -0.340927]\n",
        "  SRP000599.SRR013555: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b740> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab87c0> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.300220, -0.326339, -0.286671, 2.458255, ..., -0.139339, -0.264224, 0.603333, -0.455832]\n",
        "  SRP000599.SRR013556: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61bc00> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab8c00> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.297667, -0.322127, -0.286859, 2.919662, ..., -0.142384, 0.020815, 0.915213, -0.378093]\n",
        "  SRP000599.SRR013557: <class 'rpy2.robjects.vectors.FloatVector'>\n",
-       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61bf80> [RTYPES.REALSXP]\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f176cab8f80> [RTYPES.REALSXP]\n",
        "R classes: ('numeric',)\n",
        "[-0.310151, -0.327438, -0.286740, 1.410846, ..., -0.142232, -0.324208, 1.788489, -0.491513]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,13 +721,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
+   "id": "467cc8f7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:31.476960Z",
+     "iopub.status.busy": "2021-09-09T14:38:31.476483Z",
+     "iopub.status.idle": "2021-09-09T14:38:31.479953Z",
+     "shell.execute_reply": "2021-09-09T14:38:31.480307Z"
+    },
     "papermill": {
-     "duration": 0.03298,
-     "end_time": "2021-07-31T02:44:57.605989",
+     "duration": 0.032701,
+     "end_time": "2021-09-09T14:38:31.480432",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.573009",
+     "start_time": "2021-09-09T14:38:31.447731",
      "status": "completed"
     },
     "tags": []
@@ -713,12 +783,12 @@
        "        "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.StrVector object at 0x7f1a7d67ac80> [RTYPES.STRSXP]\n",
+       "<rpy2.robjects.vectors.StrVector object at 0x7f178c281bc0> [RTYPES.STRSXP]\n",
        "R classes: ('character',)\n",
        "['GAS6', 'MMP14', 'DSP', 'MARCKSL1', ..., 'NFIB', 'PLEKHG6', 'GNGT2', 'SERPINH1']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -729,13 +799,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
+   "id": "94189ec7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:31.540374Z",
+     "iopub.status.busy": "2021-09-09T14:38:31.539820Z",
+     "iopub.status.idle": "2021-09-09T14:38:31.543858Z",
+     "shell.execute_reply": "2021-09-09T14:38:31.544269Z"
+    },
     "papermill": {
-     "duration": 0.033832,
-     "end_time": "2021-07-31T02:44:57.663082",
+     "duration": 0.037567,
+     "end_time": "2021-09-09T14:38:31.544415",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.629250",
+     "start_time": "2021-09-09T14:38:31.506848",
      "status": "completed"
     },
     "tags": []
@@ -784,12 +861,12 @@
        "        "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.StrVector object at 0x7f1a94576300> [RTYPES.STRSXP]\n",
+       "<rpy2.robjects.vectors.StrVector object at 0x7f176ca41400> [RTYPES.STRSXP]\n",
        "R classes: ('character',)\n",
        "['SRP00059..., 'SRP00059..., 'SRP00059..., 'SRP00059..., ..., 'SRP03559..., 'SRP03559..., 'SRP03559..., 'SRP03559...]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -800,13 +877,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
+   "id": "77d6fdda",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:31.603950Z",
+     "iopub.status.busy": "2021-09-09T14:38:31.603455Z",
+     "iopub.status.idle": "2021-09-09T14:38:35.891469Z",
+     "shell.execute_reply": "2021-09-09T14:38:35.891062Z"
+    },
     "papermill": {
-     "duration": 4.160097,
-     "end_time": "2021-07-31T02:45:01.846455",
+     "duration": 4.31913,
+     "end_time": "2021-09-09T14:38:35.891578",
      "exception": false,
-     "start_time": "2021-07-31T02:44:57.686358",
+     "start_time": "2021-09-09T14:38:31.572448",
      "status": "completed"
     },
     "tags": []
@@ -819,13 +903,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
+   "id": "2d7ba7fd",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:35.949543Z",
+     "iopub.status.busy": "2021-09-09T14:38:35.949084Z",
+     "iopub.status.idle": "2021-09-09T14:38:35.951305Z",
+     "shell.execute_reply": "2021-09-09T14:38:35.950840Z"
+    },
     "papermill": {
-     "duration": 0.037696,
-     "end_time": "2021-07-31T02:45:01.908603",
+     "duration": 0.032256,
+     "end_time": "2021-09-09T14:38:35.951404",
      "exception": false,
-     "start_time": "2021-07-31T02:45:01.870907",
+     "start_time": "2021-09-09T14:38:35.919148",
      "status": "completed"
     },
     "tags": []
@@ -837,13 +928,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
+   "id": "db329251",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.008854Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.008384Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.010445Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.010823Z"
+    },
     "papermill": {
-     "duration": 0.033921,
-     "end_time": "2021-07-31T02:45:01.968398",
+     "duration": 0.032842,
+     "end_time": "2021-09-09T14:38:36.010944",
      "exception": false,
-     "start_time": "2021-07-31T02:45:01.934477",
+     "start_time": "2021-09-09T14:38:35.978102",
      "status": "completed"
     },
     "tags": []
@@ -855,7 +953,7 @@
        "(6750, 37032)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -866,13 +964,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
+   "id": "cbf74dbe",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.072099Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.071596Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.089667Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.089237Z"
+    },
     "papermill": {
-     "duration": 0.04848,
-     "end_time": "2021-07-31T02:45:02.040359",
+     "duration": 0.051799,
+     "end_time": "2021-09-09T14:38:36.089766",
      "exception": false,
-     "start_time": "2021-07-31T02:45:01.991879",
+     "start_time": "2021-09-09T14:38:36.037967",
      "status": "completed"
     },
     "tags": []
@@ -1101,7 +1206,7 @@
        "[5 rows x 37032 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1112,12 +1217,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dd6224b2",
    "metadata": {
     "papermill": {
-     "duration": 0.023732,
-     "end_time": "2021-07-31T02:45:02.088834",
+     "duration": 0.027248,
+     "end_time": "2021-09-09T14:38:36.144884",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.065102",
+     "start_time": "2021-09-09T14:38:36.117636",
      "status": "completed"
     },
     "tags": []
@@ -1128,8 +1234,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 15,
+   "id": "857f96a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.203218Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.202730Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.415778Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.415356Z"
+    },
+    "papermill": {
+     "duration": 0.243759,
+     "end_time": "2021-09-09T14:38:36.415888",
+     "exception": false,
+     "start_time": "2021-09-09T14:38:36.172129",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "assert not recount2_rpkl_cm.isna().any().any()\n",
@@ -1139,12 +1261,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "57c837d6",
    "metadata": {
     "papermill": {
-     "duration": 0.022906,
-     "end_time": "2021-07-31T02:45:02.135075",
+     "duration": 0.027215,
+     "end_time": "2021-09-09T14:38:36.470948",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.112169",
+     "start_time": "2021-09-09T14:38:36.443733",
      "status": "completed"
     },
     "tags": []
@@ -1155,13 +1278,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
+   "id": "4f25e496",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.530244Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.529741Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.532419Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.531999Z"
+    },
     "papermill": {
-     "duration": 0.033583,
-     "end_time": "2021-07-31T02:45:02.251313",
+     "duration": 0.03416,
+     "end_time": "2021-09-09T14:38:36.532517",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.217730",
+     "start_time": "2021-09-09T14:38:36.498357",
      "status": "completed"
     },
     "tags": []
@@ -1173,13 +1303,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
+   "id": "9d3506fd",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.594491Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.593971Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.595789Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.595364Z"
+    },
     "papermill": {
-     "duration": 0.033359,
-     "end_time": "2021-07-31T02:45:02.308421",
+     "duration": 0.03484,
+     "end_time": "2021-09-09T14:38:36.595895",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.275062",
+     "start_time": "2021-09-09T14:38:36.561055",
      "status": "completed"
     },
     "tags": []
@@ -1191,13 +1328,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
+   "id": "2fff9cd9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.654818Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.653307Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.656745Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.657121Z"
+    },
     "papermill": {
-     "duration": 0.033325,
-     "end_time": "2021-07-31T02:45:02.365042",
+     "duration": 0.033581,
+     "end_time": "2021-09-09T14:38:36.657243",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.331717",
+     "start_time": "2021-09-09T14:38:36.623662",
      "status": "completed"
     },
     "tags": []
@@ -1209,13 +1353,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
+   "id": "3745e06d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.716717Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.716245Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.718428Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.717978Z"
+    },
     "papermill": {
-     "duration": 0.034118,
-     "end_time": "2021-07-31T02:45:02.481967",
+     "duration": 0.032864,
+     "end_time": "2021-09-09T14:38:36.718529",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.447849",
+     "start_time": "2021-09-09T14:38:36.685665",
      "status": "completed"
     },
     "tags": []
@@ -1227,12 +1378,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "66118367",
    "metadata": {
     "papermill": {
-     "duration": 0.02375,
-     "end_time": "2021-07-31T02:45:02.529727",
+     "duration": 0.027371,
+     "end_time": "2021-09-09T14:38:36.773700",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.505977",
+     "start_time": "2021-09-09T14:38:36.746329",
      "status": "completed"
     },
     "tags": []
@@ -1243,12 +1395,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4392d44c",
    "metadata": {
     "papermill": {
-     "duration": 0.023272,
-     "end_time": "2021-07-31T02:45:02.576239",
+     "duration": 0.027384,
+     "end_time": "2021-09-09T14:38:36.828700",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.552967",
+     "start_time": "2021-09-09T14:38:36.801316",
      "status": "completed"
     },
     "tags": []
@@ -1259,13 +1412,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
+   "id": "c8767f9d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.888250Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.887698Z",
+     "iopub.status.idle": "2021-09-09T14:38:36.890676Z",
+     "shell.execute_reply": "2021-09-09T14:38:36.890215Z"
+    },
     "papermill": {
-     "duration": 0.034441,
-     "end_time": "2021-07-31T02:45:02.633861",
+     "duration": 0.034422,
+     "end_time": "2021-09-09T14:38:36.890776",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.599420",
+     "start_time": "2021-09-09T14:38:36.856354",
      "status": "completed"
     },
     "tags": []
@@ -1274,7 +1434,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_data_prep_PLIER.pkl')"
+       "PosixPath('/opt/data/data/recount2/recount_data_prep_PLIER.pkl')"
       ]
      },
      "metadata": {},
@@ -1289,13 +1449,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
+   "id": "32bf407e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:36.960764Z",
+     "iopub.status.busy": "2021-09-09T14:38:36.950469Z",
+     "iopub.status.idle": "2021-09-09T14:38:37.936544Z",
+     "shell.execute_reply": "2021-09-09T14:38:37.936109Z"
+    },
     "papermill": {
-     "duration": 12.315919,
-     "end_time": "2021-07-31T02:45:14.973790",
+     "duration": 1.017553,
+     "end_time": "2021-09-09T14:38:37.936646",
      "exception": false,
-     "start_time": "2021-07-31T02:45:02.657871",
+     "start_time": "2021-09-09T14:38:36.919093",
      "status": "completed"
     },
     "tags": []
@@ -1307,13 +1474,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
+   "id": "fa6c3035",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:37.996194Z",
+     "iopub.status.busy": "2021-09-09T14:38:37.995704Z",
+     "iopub.status.idle": "2021-09-09T14:38:37.998058Z",
+     "shell.execute_reply": "2021-09-09T14:38:37.997670Z"
+    },
     "papermill": {
-     "duration": 0.033053,
-     "end_time": "2021-07-31T02:45:15.320216",
+     "duration": 0.033247,
+     "end_time": "2021-09-09T14:38:37.998157",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.287163",
+     "start_time": "2021-09-09T14:38:37.964910",
      "status": "completed"
     },
     "tags": []
@@ -1326,12 +1500,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7fd6adde",
    "metadata": {
     "papermill": {
-     "duration": 0.042782,
-     "end_time": "2021-07-31T02:45:15.387293",
+     "duration": 0.027858,
+     "end_time": "2021-09-09T14:38:38.054233",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.344511",
+     "start_time": "2021-09-09T14:38:38.026375",
      "status": "completed"
     },
     "tags": []
@@ -1342,12 +1517,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f8ce72e5",
    "metadata": {
     "papermill": {
-     "duration": 0.042782,
-     "end_time": "2021-07-31T02:45:15.387293",
+     "duration": 0.02785,
+     "end_time": "2021-09-09T14:38:38.110397",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.344511",
+     "start_time": "2021-09-09T14:38:38.082547",
      "status": "completed"
     },
     "tags": []
@@ -1358,13 +1534,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
+   "id": "6c581c3a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.169753Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.169275Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.171889Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.171501Z"
+    },
     "papermill": {
-     "duration": 0.03543,
-     "end_time": "2021-07-31T02:45:15.452804",
+     "duration": 0.033612,
+     "end_time": "2021-09-09T14:38:38.171993",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.417374",
+     "start_time": "2021-09-09T14:38:38.138381",
      "status": "completed"
     },
     "tags": []
@@ -1376,13 +1559,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 24,
+   "id": "bd38881b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.232106Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.231621Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.235586Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.235120Z"
+    },
     "papermill": {
-     "duration": 0.040484,
-     "end_time": "2021-07-31T02:45:15.520504",
+     "duration": 0.034905,
+     "end_time": "2021-09-09T14:38:38.235685",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.480020",
+     "start_time": "2021-09-09T14:38:38.200780",
      "status": "completed"
     },
     "tags": []
@@ -1431,12 +1621,12 @@
        "        "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.FloatMatrix object at 0x7f47d8f90900> [RTYPES.REALSXP]\n",
+       "<rpy2.robjects.vectors.FloatMatrix object at 0x7f176d3f5900> [RTYPES.REALSXP]\n",
        "R classes: ('matrix', 'array')\n",
        "[0.000000, 0.000000, 0.000000, 0.000000, ..., 0.000000, 0.000000, 0.000000, 0.000000]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1447,13 +1637,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 25,
+   "id": "48576327",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.296604Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.296129Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.300450Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.299998Z"
+    },
     "papermill": {
-     "duration": 0.035708,
-     "end_time": "2021-07-31T02:45:15.582552",
+     "duration": 0.036277,
+     "end_time": "2021-09-09T14:38:38.300547",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.546844",
+     "start_time": "2021-09-09T14:38:38.264270",
      "status": "completed"
     },
     "tags": []
@@ -1502,12 +1699,12 @@
        "        "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.StrVector object at 0x7f47cfc78cc0> [RTYPES.STRSXP]\n",
+       "<rpy2.robjects.vectors.StrVector object at 0x7f176a994a80> [RTYPES.STRSXP]\n",
        "R classes: ('character',)\n",
        "['GAS6', 'MMP14', 'DSP', 'MARCKSL1', ..., 'NFIB', 'PLEKHG6', 'GNGT2', 'SERPINH1']"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1518,13 +1715,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
+   "id": "64a900d2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.361805Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.361347Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.365710Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.365301Z"
+    },
     "papermill": {
-     "duration": 0.035545,
-     "end_time": "2021-07-31T02:45:15.645756",
+     "duration": 0.036549,
+     "end_time": "2021-09-09T14:38:38.365811",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.610211",
+     "start_time": "2021-09-09T14:38:38.329262",
      "status": "completed"
     },
     "tags": []
@@ -1573,12 +1777,12 @@
        "        "
       ],
       "text/plain": [
-       "<rpy2.robjects.vectors.StrVector object at 0x7f47d8f93bc0> [RTYPES.STRSXP]\n",
+       "<rpy2.robjects.vectors.StrVector object at 0x7f17a2795280> [RTYPES.STRSXP]\n",
        "R classes: ('character',)\n",
        "['IRIS_Bce..., 'IRIS_Bce..., 'IRIS_Bce..., 'IRIS_CD4..., ..., 'REACTOME..., 'PID_BCR_..., 'PID_TELO..., 'PID_PI3K...]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1589,13 +1793,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 27,
+   "id": "ba64e214",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.429417Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.428893Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.434356Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.433903Z"
+    },
     "papermill": {
-     "duration": 0.036962,
-     "end_time": "2021-07-31T02:45:15.707676",
+     "duration": 0.038458,
+     "end_time": "2021-09-09T14:38:38.434455",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.670714",
+     "start_time": "2021-09-09T14:38:38.395997",
      "status": "completed"
     },
     "tags": []
@@ -1608,13 +1819,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 28,
+   "id": "92babf35",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.497243Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.494942Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.499503Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.499857Z"
+    },
     "papermill": {
-     "duration": 0.036475,
-     "end_time": "2021-07-31T02:45:15.771080",
+     "duration": 0.036338,
+     "end_time": "2021-09-09T14:38:38.499988",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.734605",
+     "start_time": "2021-09-09T14:38:38.463650",
      "status": "completed"
     },
     "tags": []
@@ -1632,7 +1850,7 @@
        "       [0., 0., 0., ..., 0., 0., 0.]])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1643,13 +1861,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 29,
+   "id": "5707a034",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.574197Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.573603Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.609618Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.609234Z"
+    },
     "papermill": {
-     "duration": 0.05741,
-     "end_time": "2021-07-31T02:45:15.854505",
+     "duration": 0.079248,
+     "end_time": "2021-09-09T14:38:38.609719",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.797095",
+     "start_time": "2021-09-09T14:38:38.530471",
      "status": "completed"
     },
     "tags": []
@@ -1666,13 +1891,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 30,
+   "id": "2447230d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.673006Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.672531Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.674739Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.674310Z"
+    },
     "papermill": {
-     "duration": 0.03512,
-     "end_time": "2021-07-31T02:45:15.915827",
+     "duration": 0.035285,
+     "end_time": "2021-09-09T14:38:38.674841",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.880707",
+     "start_time": "2021-09-09T14:38:38.639556",
      "status": "completed"
     },
     "tags": []
@@ -1684,13 +1916,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 31,
+   "id": "713a5836",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.739276Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.738706Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.741686Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.741218Z"
+    },
     "papermill": {
-     "duration": 0.035621,
-     "end_time": "2021-07-31T02:45:15.977134",
+     "duration": 0.036479,
+     "end_time": "2021-09-09T14:38:38.741783",
      "exception": false,
-     "start_time": "2021-07-31T02:45:15.941513",
+     "start_time": "2021-09-09T14:38:38.705304",
      "status": "completed"
     },
     "tags": []
@@ -1702,7 +1941,7 @@
        "(6750, 628)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1713,13 +1952,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 32,
+   "id": "9781e2b3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.807627Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.807048Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.810189Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.809727Z"
+    },
     "papermill": {
-     "duration": 0.035751,
-     "end_time": "2021-07-31T02:45:16.039066",
+     "duration": 0.037772,
+     "end_time": "2021-09-09T14:38:38.810287",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.003315",
+     "start_time": "2021-09-09T14:38:38.772515",
      "status": "completed"
     },
     "tags": []
@@ -1743,13 +1989,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 33,
+   "id": "ebfd50ce",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:38.887970Z",
+     "iopub.status.busy": "2021-09-09T14:38:38.887423Z",
+     "iopub.status.idle": "2021-09-09T14:38:38.890528Z",
+     "shell.execute_reply": "2021-09-09T14:38:38.890056Z"
+    },
     "papermill": {
-     "duration": 0.04761,
-     "end_time": "2021-07-31T02:45:16.113436",
+     "duration": 0.049659,
+     "end_time": "2021-09-09T14:38:38.890629",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.065826",
+     "start_time": "2021-09-09T14:38:38.840970",
      "status": "completed"
     },
     "tags": []
@@ -2006,7 +2259,7 @@
        "[5 rows x 628 columns]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2017,12 +2270,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aeb251a8",
    "metadata": {
     "papermill": {
-     "duration": 0.025519,
-     "end_time": "2021-07-31T02:45:16.165846",
+     "duration": 0.031304,
+     "end_time": "2021-09-09T14:38:38.953639",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.140327",
+     "start_time": "2021-09-09T14:38:38.922335",
      "status": "completed"
     },
     "tags": []
@@ -2033,13 +2287,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 34,
+   "id": "f41ffa08",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.020142Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.018179Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.022326Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.021858Z"
+    },
     "papermill": {
-     "duration": 0.035546,
-     "end_time": "2021-07-31T02:45:16.289602",
+     "duration": 0.037368,
+     "end_time": "2021-09-09T14:38:39.022427",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.254056",
+     "start_time": "2021-09-09T14:38:38.985059",
      "status": "completed"
     },
     "tags": []
@@ -2053,13 +2314,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 35,
+   "id": "3bd4b1ed",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.088517Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.087150Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.090703Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.090235Z"
+    },
     "papermill": {
-     "duration": 0.035206,
-     "end_time": "2021-07-31T02:45:16.350682",
+     "duration": 0.036985,
+     "end_time": "2021-09-09T14:38:39.090803",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.315476",
+     "start_time": "2021-09-09T14:38:39.053818",
      "status": "completed"
     },
     "tags": []
@@ -2071,13 +2339,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 36,
+   "id": "4e3c95d8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.156359Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.154328Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.158556Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.158151Z"
+    },
     "papermill": {
-     "duration": 0.035679,
-     "end_time": "2021-07-31T02:45:16.412543",
+     "duration": 0.037069,
+     "end_time": "2021-09-09T14:38:39.158657",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.376864",
+     "start_time": "2021-09-09T14:38:39.121588",
      "status": "completed"
     },
     "tags": []
@@ -2089,12 +2364,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "609ca9e7",
    "metadata": {
     "papermill": {
-     "duration": 0.026266,
-     "end_time": "2021-07-31T02:45:16.465891",
+     "duration": 0.031345,
+     "end_time": "2021-09-09T14:38:39.221292",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.439625",
+     "start_time": "2021-09-09T14:38:39.189947",
      "status": "completed"
     },
     "tags": []
@@ -2105,12 +2381,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4dc689ae",
    "metadata": {
     "papermill": {
-     "duration": 0.02515,
-     "end_time": "2021-07-31T02:45:16.516697",
+     "duration": 0.030983,
+     "end_time": "2021-09-09T14:38:39.283186",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.491547",
+     "start_time": "2021-09-09T14:38:39.252203",
      "status": "completed"
     },
     "tags": []
@@ -2121,13 +2398,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 37,
+   "id": "14cddc16",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.371564Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.371006Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.374088Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.373623Z"
+    },
     "papermill": {
-     "duration": 0.036328,
-     "end_time": "2021-07-31T02:45:16.578484",
+     "duration": 0.040392,
+     "end_time": "2021-09-09T14:38:39.374188",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.542156",
+     "start_time": "2021-09-09T14:38:39.333796",
      "status": "completed"
     },
     "tags": []
@@ -2136,7 +2420,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.pkl')"
+       "PosixPath('/opt/data/data/recount2/recount_all_paths_cm.pkl')"
       ]
      },
      "metadata": {},
@@ -2150,13 +2434,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 38,
+   "id": "787eb54e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.441361Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.440875Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.446056Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.446443Z"
+    },
     "papermill": {
-     "duration": 0.040513,
-     "end_time": "2021-07-31T02:45:16.645910",
+     "duration": 0.040485,
+     "end_time": "2021-09-09T14:38:39.446568",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.605397",
+     "start_time": "2021-09-09T14:38:39.406083",
      "status": "completed"
     },
     "tags": []
@@ -2168,12 +2459,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9e33c6f6",
    "metadata": {
     "papermill": {
-     "duration": 0.025829,
-     "end_time": "2021-07-31T02:45:16.763582",
+     "duration": 0.031802,
+     "end_time": "2021-09-09T14:38:39.510309",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.737753",
+     "start_time": "2021-09-09T14:38:39.478507",
      "status": "completed"
     },
     "tags": []
@@ -2184,13 +2476,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 39,
+   "id": "83aac030",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.579213Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.578695Z",
+     "iopub.status.idle": "2021-09-09T14:38:39.581020Z",
+     "shell.execute_reply": "2021-09-09T14:38:39.581403Z"
+    },
     "papermill": {
-     "duration": 0.036739,
-     "end_time": "2021-07-31T02:45:16.827294",
+     "duration": 0.039349,
+     "end_time": "2021-09-09T14:38:39.581537",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.790555",
+     "start_time": "2021-09-09T14:38:39.542188",
      "status": "completed"
     },
     "tags": []
@@ -2199,7 +2498,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.rds')"
+       "PosixPath('/opt/data/data/recount2/recount_all_paths_cm.rds')"
       ]
      },
      "metadata": {},
@@ -2213,13 +2512,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 40,
+   "id": "f509e045",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:39.651430Z",
+     "iopub.status.busy": "2021-09-09T14:38:39.650963Z",
+     "iopub.status.idle": "2021-09-09T14:38:40.001562Z",
+     "shell.execute_reply": "2021-09-09T14:38:40.001090Z"
+    },
     "papermill": {
-     "duration": 0.306655,
-     "end_time": "2021-07-31T02:45:17.160491",
+     "duration": 0.386225,
+     "end_time": "2021-09-09T14:38:40.001662",
      "exception": false,
-     "start_time": "2021-07-31T02:45:16.853836",
+     "start_time": "2021-09-09T14:38:39.615437",
      "status": "completed"
     },
     "tags": []
@@ -2228,10 +2534,10 @@
     {
      "data": {
       "text/plain": [
-       "<rpy2.rinterface_lib.sexp.NULLType object at 0x7f47d9752980> [RTYPES.NILSXP]"
+       "<rpy2.rinterface_lib.sexp.NULLType object at 0x7f176d3f5540> [RTYPES.NILSXP]"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2242,12 +2548,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "50838611",
    "metadata": {
     "papermill": {
-     "duration": 0.026717,
-     "end_time": "2021-07-31T02:45:17.277986",
+     "duration": 0.032345,
+     "end_time": "2021-09-09T14:38:40.066874",
      "exception": false,
-     "start_time": "2021-07-31T02:45:17.251269",
+     "start_time": "2021-09-09T14:38:40.034529",
      "status": "completed"
     },
     "tags": []
@@ -2258,13 +2565,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 41,
+   "id": "d0529a7a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:40.135617Z",
+     "iopub.status.busy": "2021-09-09T14:38:40.135136Z",
+     "iopub.status.idle": "2021-09-09T14:38:40.137936Z",
+     "shell.execute_reply": "2021-09-09T14:38:40.137552Z"
+    },
     "papermill": {
-     "duration": 0.037402,
-     "end_time": "2021-07-31T02:45:17.342145",
+     "duration": 0.039047,
+     "end_time": "2021-09-09T14:38:40.138032",
      "exception": false,
-     "start_time": "2021-07-31T02:45:17.304743",
+     "start_time": "2021-09-09T14:38:40.098985",
      "status": "completed"
     },
     "tags": []
@@ -2273,7 +2587,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.tsv.gz')"
+       "PosixPath('/opt/data/data/recount2/recount_all_paths_cm.tsv.gz')"
       ]
      },
      "metadata": {},
@@ -2288,13 +2602,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 42,
+   "id": "c4b1a8dc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:40.207113Z",
+     "iopub.status.busy": "2021-09-09T14:38:40.206557Z",
+     "iopub.status.idle": "2021-09-09T14:38:40.228079Z",
+     "shell.execute_reply": "2021-09-09T14:38:40.227652Z"
+    },
     "papermill": {
-     "duration": 0.048243,
-     "end_time": "2021-07-31T02:45:17.418720",
+     "duration": 0.057488,
+     "end_time": "2021-09-09T14:38:40.228179",
      "exception": false,
-     "start_time": "2021-07-31T02:45:17.370477",
+     "start_time": "2021-09-09T14:38:40.170691",
      "status": "completed"
     },
     "tags": []
@@ -2551,7 +2872,7 @@
        "[5 rows x 628 columns]"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2562,13 +2883,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 43,
+   "id": "8c1cb280",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T14:38:40.298742Z",
+     "iopub.status.busy": "2021-09-09T14:38:40.298187Z",
+     "iopub.status.idle": "2021-09-09T14:38:41.155679Z",
+     "shell.execute_reply": "2021-09-09T14:38:41.155038Z"
+    },
     "papermill": {
-     "duration": 0.74306,
-     "end_time": "2021-07-31T02:45:18.194610",
+     "duration": 0.8941,
+     "end_time": "2021-09-09T14:38:41.155783",
      "exception": false,
-     "start_time": "2021-07-31T02:45:17.451550",
+     "start_time": "2021-09-09T14:38:40.261683",
      "status": "completed"
     },
     "tags": []
@@ -2581,12 +2909,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5f8a298c",
    "metadata": {
     "papermill": {
-     "duration": 0.02695,
-     "end_time": "2021-07-31T02:45:18.315645",
+     "duration": 0.03321,
+     "end_time": "2021-09-09T14:38:41.222359",
      "exception": false,
-     "start_time": "2021-07-31T02:45:18.288695",
+     "start_time": "2021-09-09T14:38:41.189149",
      "status": "completed"
     },
     "tags": []
@@ -2615,21 +2944,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 37.218887,
-   "end_time": "2021-07-31T02:45:20.046262",
+   "duration": 25.979398,
+   "end_time": "2021-09-09T14:38:42.063294",
    "environment_variables": {},
    "exception": null,
-   "input_path": "01_preprocessing/005-multiplier_recount2_data.ipynb",
-   "output_path": "01_preprocessing/005-multiplier_recount2_data.run.ipynb",
+   "input_path": "nbs/05_preprocessing/10-recount2_multiplier-format.ipynb",
+   "output_path": "nbs/05_preprocessing/10-recount2_multiplier-format.run.ipynb",
    "parameters": {},
-   "start_time": "2021-07-31T02:44:42.827375",
+   "start_time": "2021-09-09T14:38:16.083896",
    "version": "2.2.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
+++ b/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
@@ -1,0 +1,2635 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028312,
+     "end_time": "2021-07-31T02:44:43.844573",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:43.816261",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021036,
+     "end_time": "2021-07-31T02:44:43.888392",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:43.867356",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "This notebook reads 1) the normalized gene expression and 2) pathways from the data processed by\n",
+    "MultiPLIER scripts (https://github.com/greenelab/multi-plier) and saves it into a more friendly Python\n",
+    "format (Pandas DataFrames as pickle files)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021103,
+     "end_time": "2021-07-31T02:44:43.930581",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:43.909478",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "papermill": {
+     "duration": 0.437138,
+     "end_time": "2021-07-31T02:44:44.444679",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.007541",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "from shutil import copyfile\n",
+    "\n",
+    "import pandas as pd\n",
+    "import rpy2.robjects as ro\n",
+    "from rpy2.robjects import pandas2ri\n",
+    "from rpy2.robjects.conversion import localconverter\n",
+    "\n",
+    "from clustermatch import conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "papermill": {
+     "duration": 0.032406,
+     "end_time": "2021-07-31T02:44:44.498981",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.466575",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "readRDS = ro.r[\"readRDS\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "papermill": {
+     "duration": 0.031723,
+     "end_time": "2021-07-31T02:44:44.553118",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.521395",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "saveRDS = ro.r[\"saveRDS\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021057,
+     "end_time": "2021-07-31T02:44:44.595949",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.574892",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033301,
+     "end_time": "2021-07-31T02:44:44.717183",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.683882",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "OUTPUT_DIR = conf.RECOUNT2[\"DATA_RDS_FILE\"].parent\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "display(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021698,
+     "end_time": "2021-07-31T02:44:44.761260",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.739562",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Read entire recount data prep file with R"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "papermill": {
+     "duration": 0.034664,
+     "end_time": "2021-07-31T02:44:44.817090",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.782426",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_data_prep_PLIER.RDS')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(conf.RECOUNT2[\"DATA_RDS_FILE\"])\n",
+    "\n",
+    "if not conf.RECOUNT2[\"DATA_RDS_FILE\"].exists():\n",
+    "    print(\"Input file does not exist\")\n",
+    "    sys.exit(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "papermill": {
+     "duration": 12.550085,
+     "end_time": "2021-07-31T02:44:57.393996",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:44.843911",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount_data_prep = readRDS(str(conf.RECOUNT2[\"DATA_RDS_FILE\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021193,
+     "end_time": "2021-07-31T02:44:57.438041",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.416848",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# recount2 gene expression data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021193,
+     "end_time": "2021-07-31T02:44:57.438041",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.416848",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "papermill": {
+     "duration": 0.031948,
+     "end_time": "2021-07-31T02:44:57.491486",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.459538",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_rpkl_cm = recount_data_prep.rx2(\"rpkm.cm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "papermill": {
+     "duration": 0.036813,
+     "end_time": "2021-07-31T02:44:57.550537",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.513724",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>R/rpy2 DataFrame (6750 x 37032)</span>\n",
+       "        <table>\n",
+       "          <thead>\n",
+       "            <tr>\n",
+       "              \n",
+       "              <th>SRP000599.SRR013549</th>\n",
+       "              \n",
+       "              <th>SRP000599.SRR013550</th>\n",
+       "              \n",
+       "              <th>SRP000599.SRR013551</th>\n",
+       "              \n",
+       "              <th>...</th>\n",
+       "              \n",
+       "              <th>SRP035599.SRR1139382</th>\n",
+       "              \n",
+       "              <th>SRP035599.SRR1139356</th>\n",
+       "              \n",
+       "              <th>SRP035599.SRR1139370</th>\n",
+       "              \n",
+       "            </tr>\n",
+       "          </thead>\n",
+       "          <tbody>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.312500\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.312931\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.312931\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.300220\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.297667\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.310151\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.328279\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.328279\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.328279\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.326339\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.322127\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.327438\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286319\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286859\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286859\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286671\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286859\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.286740\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.536646\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.536646\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.536646\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              2.458255\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              2.919662\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              1.410846\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.142179\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.142384\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.140314\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.139339\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.142384\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.142232\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.349886\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.349886\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.349886\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.264224\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.020815\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.324208\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.085582\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.085582\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.085582\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.603333\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.915213\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              1.788489\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.567112\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.569146\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.569146\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.455832\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.378093\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              -0.491513\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          </tbody>\n",
+       "        </table>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.DataFrame object at 0x7f1a94576540> [RTYPES.VECSXP]\n",
+       "R classes: ('data.frame',)\n",
+       "[FloatSexp..., FloatSexp..., FloatSexp..., FloatSexp..., ..., FloatSexp..., FloatSexp..., FloatSexp..., FloatSexp...]\n",
+       "  SRP000599.SRR013549: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d615140> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.312500, -0.328279, -0.286319, -0.536646, ..., -0.142179, -0.349886, -0.085582, -0.567112]\n",
+       "  SRP000599.SRR013550: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d660040> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.142384, -0.349886, -0.085582, -0.569146]\n",
+       "  SRP000599.SRR013551: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b2c0> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.140314, -0.349886, -0.085582, -0.569146]\n",
+       "  SRP000599.SRR013552: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b280> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.312931, -0.328279, -0.286859, -0.536646, ..., -0.142384, -0.349886, -0.085582, -0.569146]\n",
+       "...\n",
+       "  SRP000599.SRR013554: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b880> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.309599, -0.326375, -0.286859, 1.507099, ..., -0.142304, -0.149655, 1.280258, -0.340927]\n",
+       "  SRP000599.SRR013555: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61b740> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.300220, -0.326339, -0.286671, 2.458255, ..., -0.139339, -0.264224, 0.603333, -0.455832]\n",
+       "  SRP000599.SRR013556: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61bc00> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.297667, -0.322127, -0.286859, 2.919662, ..., -0.142384, 0.020815, 0.915213, -0.378093]\n",
+       "  SRP000599.SRR013557: <class 'rpy2.robjects.vectors.FloatVector'>\n",
+       "  <rpy2.robjects.vectors.FloatVector object at 0x7f1a7d61bf80> [RTYPES.REALSXP]\n",
+       "R classes: ('numeric',)\n",
+       "[-0.310151, -0.327438, -0.286740, 1.410846, ..., -0.142232, -0.324208, 1.788489, -0.491513]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_rpkl_cm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "papermill": {
+     "duration": 0.03298,
+     "end_time": "2021-07-31T02:44:57.605989",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.573009",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>StrVector with 6750 elements.</span>\n",
+       "        <table>\n",
+       "        <tbody>\n",
+       "          <tr>\n",
+       "          \n",
+       "            <td>\n",
+       "            'GAS6'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'MMP14'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'DSP'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            ...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'PLEKHG6'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'GNGT2'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SERPINH1'\n",
+       "            </td>\n",
+       "          \n",
+       "          </tr>\n",
+       "        </tbody>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.StrVector object at 0x7f1a7d67ac80> [RTYPES.STRSXP]\n",
+       "R classes: ('character',)\n",
+       "['GAS6', 'MMP14', 'DSP', 'MARCKSL1', ..., 'NFIB', 'PLEKHG6', 'GNGT2', 'SERPINH1']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_rpkl_cm.rownames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033832,
+     "end_time": "2021-07-31T02:44:57.663082",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.629250",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>StrVector with 37032 elements.</span>\n",
+       "        <table>\n",
+       "        <tbody>\n",
+       "          <tr>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP00059...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP00059...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP00059...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            ...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP03559...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP03559...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SRP03559...\n",
+       "            </td>\n",
+       "          \n",
+       "          </tr>\n",
+       "        </tbody>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.StrVector object at 0x7f1a94576300> [RTYPES.STRSXP]\n",
+       "R classes: ('character',)\n",
+       "['SRP00059..., 'SRP00059..., 'SRP00059..., 'SRP00059..., ..., 'SRP03559..., 'SRP03559..., 'SRP03559..., 'SRP03559...]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_rpkl_cm.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "papermill": {
+     "duration": 4.160097,
+     "end_time": "2021-07-31T02:45:01.846455",
+     "exception": false,
+     "start_time": "2021-07-31T02:44:57.686358",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with localconverter(ro.default_converter + pandas2ri.converter):\n",
+    "    recount2_rpkl_cm = ro.conversion.rpy2py(recount2_rpkl_cm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "papermill": {
+     "duration": 0.037696,
+     "end_time": "2021-07-31T02:45:01.908603",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:01.870907",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_rpkl_cm.shape == (6750, 37032)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033921,
+     "end_time": "2021-07-31T02:45:01.968398",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:01.934477",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 37032)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_rpkl_cm.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "papermill": {
+     "duration": 0.04848,
+     "end_time": "2021-07-31T02:45:02.040359",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:01.991879",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SRP000599.SRR013549</th>\n",
+       "      <th>SRP000599.SRR013550</th>\n",
+       "      <th>SRP000599.SRR013551</th>\n",
+       "      <th>SRP000599.SRR013552</th>\n",
+       "      <th>SRP000599.SRR013553</th>\n",
+       "      <th>SRP000599.SRR013554</th>\n",
+       "      <th>SRP000599.SRR013555</th>\n",
+       "      <th>SRP000599.SRR013556</th>\n",
+       "      <th>SRP000599.SRR013557</th>\n",
+       "      <th>SRP000599.SRR013558</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SRP035599.SRR1139372</th>\n",
+       "      <th>SRP035599.SRR1139393</th>\n",
+       "      <th>SRP035599.SRR1139388</th>\n",
+       "      <th>SRP035599.SRR1139378</th>\n",
+       "      <th>SRP035599.SRR1139399</th>\n",
+       "      <th>SRP035599.SRR1139386</th>\n",
+       "      <th>SRP035599.SRR1139375</th>\n",
+       "      <th>SRP035599.SRR1139382</th>\n",
+       "      <th>SRP035599.SRR1139356</th>\n",
+       "      <th>SRP035599.SRR1139370</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>-0.312500</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.308253</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.301711</td>\n",
+       "      <td>-0.305581</td>\n",
+       "      <td>-0.303344</td>\n",
+       "      <td>-0.297800</td>\n",
+       "      <td>-0.307122</td>\n",
+       "      <td>-0.285499</td>\n",
+       "      <td>-0.309599</td>\n",
+       "      <td>-0.300220</td>\n",
+       "      <td>-0.297667</td>\n",
+       "      <td>-0.310151</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.325140</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.314587</td>\n",
+       "      <td>-0.322952</td>\n",
+       "      <td>-0.326439</td>\n",
+       "      <td>-0.325994</td>\n",
+       "      <td>-0.326272</td>\n",
+       "      <td>-0.322523</td>\n",
+       "      <td>-0.326375</td>\n",
+       "      <td>-0.326339</td>\n",
+       "      <td>-0.322127</td>\n",
+       "      <td>-0.327438</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>-0.286319</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.277195</td>\n",
+       "      <td>-0.256862</td>\n",
+       "      <td>-0.278790</td>\n",
+       "      <td>-0.269701</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286745</td>\n",
+       "      <td>-0.286688</td>\n",
+       "      <td>-0.286725</td>\n",
+       "      <td>-0.286529</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286671</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.807663</td>\n",
+       "      <td>1.294564</td>\n",
+       "      <td>1.527655</td>\n",
+       "      <td>1.404788</td>\n",
+       "      <td>1.047931</td>\n",
+       "      <td>0.892119</td>\n",
+       "      <td>1.507099</td>\n",
+       "      <td>2.458255</td>\n",
+       "      <td>2.919662</td>\n",
+       "      <td>1.410846</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.369171</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.345409</td>\n",
+       "      <td>-0.310750</td>\n",
+       "      <td>-0.348120</td>\n",
+       "      <td>-0.356938</td>\n",
+       "      <td>-0.355206</td>\n",
+       "      <td>-0.366197</td>\n",
+       "      <td>-0.351174</td>\n",
+       "      <td>-0.363703</td>\n",
+       "      <td>-0.350825</td>\n",
+       "      <td>-0.360762</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 37032 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          SRP000599.SRR013549  SRP000599.SRR013550  SRP000599.SRR013551  \\\n",
+       "GAS6                -0.312500            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286319            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.369171   \n",
+       "\n",
+       "          SRP000599.SRR013552  SRP000599.SRR013553  SRP000599.SRR013554  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.308253   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286859            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013555  SRP000599.SRR013556  SRP000599.SRR013557  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.277195            -0.256862            -0.278790   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013558  ...  SRP035599.SRR1139372  \\\n",
+       "GAS6                -0.312931  ...             -0.301711   \n",
+       "MMP14               -0.325140  ...             -0.314587   \n",
+       "DSP                 -0.269701  ...             -0.286859   \n",
+       "MARCKSL1            -0.536646  ...              0.807663   \n",
+       "SPARC               -0.370498  ...             -0.345409   \n",
+       "\n",
+       "          SRP035599.SRR1139393  SRP035599.SRR1139388  SRP035599.SRR1139378  \\\n",
+       "GAS6                 -0.305581             -0.303344             -0.297800   \n",
+       "MMP14                -0.322952             -0.326439             -0.325994   \n",
+       "DSP                  -0.286859             -0.286745             -0.286688   \n",
+       "MARCKSL1              1.294564              1.527655              1.404788   \n",
+       "SPARC                -0.310750             -0.348120             -0.356938   \n",
+       "\n",
+       "          SRP035599.SRR1139399  SRP035599.SRR1139386  SRP035599.SRR1139375  \\\n",
+       "GAS6                 -0.307122             -0.285499             -0.309599   \n",
+       "MMP14                -0.326272             -0.322523             -0.326375   \n",
+       "DSP                  -0.286725             -0.286529             -0.286859   \n",
+       "MARCKSL1              1.047931              0.892119              1.507099   \n",
+       "SPARC                -0.355206             -0.366197             -0.351174   \n",
+       "\n",
+       "          SRP035599.SRR1139382  SRP035599.SRR1139356  SRP035599.SRR1139370  \n",
+       "GAS6                 -0.300220             -0.297667             -0.310151  \n",
+       "MMP14                -0.326339             -0.322127             -0.327438  \n",
+       "DSP                  -0.286671             -0.286859             -0.286740  \n",
+       "MARCKSL1              2.458255              2.919662              1.410846  \n",
+       "SPARC                -0.363703             -0.350825             -0.360762  \n",
+       "\n",
+       "[5 rows x 37032 columns]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_rpkl_cm.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023732,
+     "end_time": "2021-07-31T02:45:02.088834",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.065102",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert not recount2_rpkl_cm.isna().any().any()\n",
+    "assert recount2_rpkl_cm.index.is_unique\n",
+    "assert recount2_rpkl_cm.columns.is_unique"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022906,
+     "end_time": "2021-07-31T02:45:02.135075",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.112169",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Test whether what I load from a plain R session is the same as in here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033583,
+     "end_time": "2021-07-31T02:45:02.251313",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.217730",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_rpkl_cm.loc[\"GAS6\", \"SRP000599.SRR013549\"].round(4) == -0.3125"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033359,
+     "end_time": "2021-07-31T02:45:02.308421",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.275062",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_rpkl_cm.loc[\"GAS6\", \"SRP045352.SRR1539229\"].round(7) == -0.2843801"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033325,
+     "end_time": "2021-07-31T02:45:02.365042",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.331717",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_rpkl_cm.loc[\"CFL2\", \"SRP056840.SRR1951636\"].round(7) == -0.3412832"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "papermill": {
+     "duration": 0.034118,
+     "end_time": "2021-07-31T02:45:02.481967",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.447849",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_rpkl_cm.iloc[9, 16].round(7) == -0.4938852"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02375,
+     "end_time": "2021-07-31T02:45:02.529727",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.505977",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Save"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023272,
+     "end_time": "2021-07-31T02:45:02.576239",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.552967",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pickle format (binary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "papermill": {
+     "duration": 0.034441,
+     "end_time": "2021-07-31T02:45:02.633861",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.599420",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_data_prep_PLIER.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "output_filename = conf.RECOUNT2[\"DATA_FILE\"]\n",
+    "\n",
+    "display(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "papermill": {
+     "duration": 12.315919,
+     "end_time": "2021-07-31T02:45:14.973790",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:02.657871",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_rpkl_cm.to_pickle(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "papermill": {
+     "duration": 0.033053,
+     "end_time": "2021-07-31T02:45:15.320216",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.287163",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# delete the object to save memory\n",
+    "del recount2_rpkl_cm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.042782,
+     "end_time": "2021-07-31T02:45:15.387293",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.344511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# recount2 pathways"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.042782,
+     "end_time": "2021-07-31T02:45:15.387293",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.344511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "papermill": {
+     "duration": 0.03543,
+     "end_time": "2021-07-31T02:45:15.452804",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.417374",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_all_paths_cm = recount_data_prep.rx2(\"all.paths.cm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "papermill": {
+     "duration": 0.040484,
+     "end_time": "2021-07-31T02:45:15.520504",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.480020",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>FloatMatrix with 4239000 elements.</span>\n",
+       "        <table>\n",
+       "        <tbody>\n",
+       "          <tr>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            ...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            0.000000\n",
+       "            </td>\n",
+       "          \n",
+       "          </tr>\n",
+       "        </tbody>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.FloatMatrix object at 0x7f47d8f90900> [RTYPES.REALSXP]\n",
+       "R classes: ('matrix', 'array')\n",
+       "[0.000000, 0.000000, 0.000000, 0.000000, ..., 0.000000, 0.000000, 0.000000, 0.000000]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035708,
+     "end_time": "2021-07-31T02:45:15.582552",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.546844",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>StrVector with 6750 elements.</span>\n",
+       "        <table>\n",
+       "        <tbody>\n",
+       "          <tr>\n",
+       "          \n",
+       "            <td>\n",
+       "            'GAS6'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'MMP14'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'DSP'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            ...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'PLEKHG6'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'GNGT2'\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'SERPINH1'\n",
+       "            </td>\n",
+       "          \n",
+       "          </tr>\n",
+       "        </tbody>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.StrVector object at 0x7f47cfc78cc0> [RTYPES.STRSXP]\n",
+       "R classes: ('character',)\n",
+       "['GAS6', 'MMP14', 'DSP', 'MARCKSL1', ..., 'NFIB', 'PLEKHG6', 'GNGT2', 'SERPINH1']"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm.rownames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035545,
+     "end_time": "2021-07-31T02:45:15.645756",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.610211",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>StrVector with 628 elements.</span>\n",
+       "        <table>\n",
+       "        <tbody>\n",
+       "          <tr>\n",
+       "          \n",
+       "            <td>\n",
+       "            'IRIS_Bce...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'IRIS_Bce...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'IRIS_Bce...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            ...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'PID_BCR_...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'PID_TELO...\n",
+       "            </td>\n",
+       "          \n",
+       "            <td>\n",
+       "            'PID_PI3K...\n",
+       "            </td>\n",
+       "          \n",
+       "          </tr>\n",
+       "        </tbody>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<rpy2.robjects.vectors.StrVector object at 0x7f47d8f93bc0> [RTYPES.STRSXP]\n",
+       "R classes: ('character',)\n",
+       "['IRIS_Bce..., 'IRIS_Bce..., 'IRIS_Bce..., 'IRIS_CD4..., ..., 'REACTOME..., 'PID_BCR_..., 'PID_TELO..., 'PID_PI3K...]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "papermill": {
+     "duration": 0.036962,
+     "end_time": "2021-07-31T02:45:15.707676",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.670714",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with localconverter(ro.default_converter + pandas2ri.converter):\n",
+    "    recount2_all_paths_cm_values = ro.conversion.rpy2py(recount2_all_paths_cm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "papermill": {
+     "duration": 0.036475,
+     "end_time": "2021-07-31T02:45:15.771080",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.734605",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0., 0., 0., ..., 0., 0., 0.],\n",
+       "       [0., 0., 0., ..., 0., 0., 0.],\n",
+       "       [0., 0., 1., ..., 0., 0., 0.],\n",
+       "       ...,\n",
+       "       [0., 0., 0., ..., 0., 0., 0.],\n",
+       "       [0., 0., 0., ..., 0., 0., 0.],\n",
+       "       [0., 0., 0., ..., 0., 0., 0.]])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "papermill": {
+     "duration": 0.05741,
+     "end_time": "2021-07-31T02:45:15.854505",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.797095",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_all_paths_cm_df = pd.DataFrame(\n",
+    "    data=recount2_all_paths_cm_values,\n",
+    "    index=recount2_all_paths_cm.rownames,\n",
+    "    columns=recount2_all_paths_cm.colnames,\n",
+    "    dtype=bool,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "papermill": {
+     "duration": 0.03512,
+     "end_time": "2021-07-31T02:45:15.915827",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.880707",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_all_paths_cm_df.shape == (6750, 628)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035621,
+     "end_time": "2021-07-31T02:45:15.977134",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:15.941513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 628)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035751,
+     "end_time": "2021-07-31T02:45:16.039066",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.003315",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([dtype('bool')], dtype=object)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_tmp = recount2_all_paths_cm_df.dtypes.unique()\n",
+    "display(_tmp)\n",
+    "assert len(_tmp) == 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "papermill": {
+     "duration": 0.04761,
+     "end_time": "2021-07-31T02:45:16.113436",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.065826",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IRIS_Bcell-Memory_IgG_IgA</th>\n",
+       "      <th>IRIS_Bcell-Memory_IgM</th>\n",
+       "      <th>IRIS_Bcell-naive</th>\n",
+       "      <th>IRIS_CD4Tcell-N0</th>\n",
+       "      <th>IRIS_CD4Tcell-Th1-restimulated12hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th1-restimulated48hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th2-restimulated12hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th2-restimulated48hour</th>\n",
+       "      <th>IRIS_CD8Tcell-N0</th>\n",
+       "      <th>IRIS_DendriticCell-Control</th>\n",
+       "      <th>...</th>\n",
+       "      <th>KEGG_GNRH_SIGNALING_PATHWAY</th>\n",
+       "      <th>KEGG_BASAL_TRANSCRIPTION_FACTORS</th>\n",
+       "      <th>REACTOME_SYNTHESIS_OF_DNA</th>\n",
+       "      <th>KEGG_HEMATOPOIETIC_CELL_LINEAGE</th>\n",
+       "      <th>KEGG_T_CELL_RECEPTOR_SIGNALING_PATHWAY</th>\n",
+       "      <th>PID_IL4_2PATHWAY</th>\n",
+       "      <th>REACTOME_SIGNALING_BY_THE_B_CELL_RECEPTOR_BCR</th>\n",
+       "      <th>PID_BCR_5PATHWAY</th>\n",
+       "      <th>PID_TELOMERASEPATHWAY</th>\n",
+       "      <th>PID_PI3KPLCTRKPATHWAY</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 628 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          IRIS_Bcell-Memory_IgG_IgA  IRIS_Bcell-Memory_IgM  IRIS_Bcell-naive  \\\n",
+       "GAS6                          False                  False             False   \n",
+       "MMP14                         False                  False             False   \n",
+       "DSP                           False                  False              True   \n",
+       "MARCKSL1                      False                  False             False   \n",
+       "SPARC                         False                  False             False   \n",
+       "\n",
+       "          IRIS_CD4Tcell-N0  IRIS_CD4Tcell-Th1-restimulated12hour  \\\n",
+       "GAS6                 False                                 False   \n",
+       "MMP14                False                                 False   \n",
+       "DSP                  False                                 False   \n",
+       "MARCKSL1             False                                 False   \n",
+       "SPARC                False                                 False   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th1-restimulated48hour  \\\n",
+       "GAS6                                     False   \n",
+       "MMP14                                    False   \n",
+       "DSP                                      False   \n",
+       "MARCKSL1                                 False   \n",
+       "SPARC                                    False   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th2-restimulated12hour  \\\n",
+       "GAS6                                     False   \n",
+       "MMP14                                    False   \n",
+       "DSP                                      False   \n",
+       "MARCKSL1                                 False   \n",
+       "SPARC                                    False   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th2-restimulated48hour  IRIS_CD8Tcell-N0  \\\n",
+       "GAS6                                     False             False   \n",
+       "MMP14                                    False             False   \n",
+       "DSP                                      False             False   \n",
+       "MARCKSL1                                 False             False   \n",
+       "SPARC                                    False             False   \n",
+       "\n",
+       "          IRIS_DendriticCell-Control  ...  KEGG_GNRH_SIGNALING_PATHWAY  \\\n",
+       "GAS6                            True  ...                        False   \n",
+       "MMP14                          False  ...                         True   \n",
+       "DSP                            False  ...                        False   \n",
+       "MARCKSL1                       False  ...                        False   \n",
+       "SPARC                          False  ...                        False   \n",
+       "\n",
+       "          KEGG_BASAL_TRANSCRIPTION_FACTORS  REACTOME_SYNTHESIS_OF_DNA  \\\n",
+       "GAS6                                 False                      False   \n",
+       "MMP14                                False                      False   \n",
+       "DSP                                  False                      False   \n",
+       "MARCKSL1                             False                      False   \n",
+       "SPARC                                False                      False   \n",
+       "\n",
+       "          KEGG_HEMATOPOIETIC_CELL_LINEAGE  \\\n",
+       "GAS6                                False   \n",
+       "MMP14                               False   \n",
+       "DSP                                 False   \n",
+       "MARCKSL1                            False   \n",
+       "SPARC                               False   \n",
+       "\n",
+       "          KEGG_T_CELL_RECEPTOR_SIGNALING_PATHWAY  PID_IL4_2PATHWAY  \\\n",
+       "GAS6                                       False             False   \n",
+       "MMP14                                      False             False   \n",
+       "DSP                                        False             False   \n",
+       "MARCKSL1                                   False             False   \n",
+       "SPARC                                      False             False   \n",
+       "\n",
+       "          REACTOME_SIGNALING_BY_THE_B_CELL_RECEPTOR_BCR  PID_BCR_5PATHWAY  \\\n",
+       "GAS6                                              False             False   \n",
+       "MMP14                                             False             False   \n",
+       "DSP                                               False             False   \n",
+       "MARCKSL1                                          False             False   \n",
+       "SPARC                                             False             False   \n",
+       "\n",
+       "          PID_TELOMERASEPATHWAY  PID_PI3KPLCTRKPATHWAY  \n",
+       "GAS6                      False                  False  \n",
+       "MMP14                     False                  False  \n",
+       "DSP                       False                  False  \n",
+       "MARCKSL1                  False                  False  \n",
+       "SPARC                     False                  False  \n",
+       "\n",
+       "[5 rows x 628 columns]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025519,
+     "end_time": "2021-07-31T02:45:16.165846",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.140327",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035546,
+     "end_time": "2021-07-31T02:45:16.289602",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.254056",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert not recount2_all_paths_cm_df.loc[\n",
+    "    \"CTSD\", \"REACTOME_SCFSKP2_MEDIATED_DEGRADATION_OF_P27_P21\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035206,
+     "end_time": "2021-07-31T02:45:16.350682",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.315476",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_all_paths_cm_df.loc[\"CTSD\", \"PID_P53DOWNSTREAMPATHWAY\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "papermill": {
+     "duration": 0.035679,
+     "end_time": "2021-07-31T02:45:16.412543",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.376864",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert recount2_all_paths_cm_df.loc[\"MMP14\", \"PID_HIF2PATHWAY\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026266,
+     "end_time": "2021-07-31T02:45:16.465891",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.439625",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Save"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02515,
+     "end_time": "2021-07-31T02:45:16.516697",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.491547",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pickle format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "papermill": {
+     "duration": 0.036328,
+     "end_time": "2021-07-31T02:45:16.578484",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.542156",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "output_filename = conf.RECOUNT2[\"DATA_FILE\"].parent / \"recount_all_paths_cm.pkl\"\n",
+    "display(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "papermill": {
+     "duration": 0.040513,
+     "end_time": "2021-07-31T02:45:16.645910",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.605397",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_all_paths_cm_df.to_pickle(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025829,
+     "end_time": "2021-07-31T02:45:16.763582",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.737753",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### RDS format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "papermill": {
+     "duration": 0.036739,
+     "end_time": "2021-07-31T02:45:16.827294",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.790555",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.rds')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "output_rds_file = output_filename.with_suffix(\".rds\")\n",
+    "display(output_rds_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "papermill": {
+     "duration": 0.306655,
+     "end_time": "2021-07-31T02:45:17.160491",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:16.853836",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rpy2.rinterface_lib.sexp.NULLType object at 0x7f47d9752980> [RTYPES.NILSXP]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "saveRDS(recount2_all_paths_cm, str(output_rds_file))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026717,
+     "end_time": "2021-07-31T02:45:17.277986",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:17.251269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Text format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "papermill": {
+     "duration": 0.037402,
+     "end_time": "2021-07-31T02:45:17.342145",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:17.304743",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr/base/data/recount2/recount_all_paths_cm.tsv.gz')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# tsv format\n",
+    "output_text_file = output_filename.with_suffix(\".tsv.gz\")\n",
+    "display(output_text_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "papermill": {
+     "duration": 0.048243,
+     "end_time": "2021-07-31T02:45:17.418720",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:17.370477",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IRIS_Bcell-Memory_IgG_IgA</th>\n",
+       "      <th>IRIS_Bcell-Memory_IgM</th>\n",
+       "      <th>IRIS_Bcell-naive</th>\n",
+       "      <th>IRIS_CD4Tcell-N0</th>\n",
+       "      <th>IRIS_CD4Tcell-Th1-restimulated12hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th1-restimulated48hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th2-restimulated12hour</th>\n",
+       "      <th>IRIS_CD4Tcell-Th2-restimulated48hour</th>\n",
+       "      <th>IRIS_CD8Tcell-N0</th>\n",
+       "      <th>IRIS_DendriticCell-Control</th>\n",
+       "      <th>...</th>\n",
+       "      <th>KEGG_GNRH_SIGNALING_PATHWAY</th>\n",
+       "      <th>KEGG_BASAL_TRANSCRIPTION_FACTORS</th>\n",
+       "      <th>REACTOME_SYNTHESIS_OF_DNA</th>\n",
+       "      <th>KEGG_HEMATOPOIETIC_CELL_LINEAGE</th>\n",
+       "      <th>KEGG_T_CELL_RECEPTOR_SIGNALING_PATHWAY</th>\n",
+       "      <th>PID_IL4_2PATHWAY</th>\n",
+       "      <th>REACTOME_SIGNALING_BY_THE_B_CELL_RECEPTOR_BCR</th>\n",
+       "      <th>PID_BCR_5PATHWAY</th>\n",
+       "      <th>PID_TELOMERASEPATHWAY</th>\n",
+       "      <th>PID_PI3KPLCTRKPATHWAY</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 628 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          IRIS_Bcell-Memory_IgG_IgA  IRIS_Bcell-Memory_IgM  IRIS_Bcell-naive  \\\n",
+       "GAS6                              0                      0                 0   \n",
+       "MMP14                             0                      0                 0   \n",
+       "DSP                               0                      0                 1   \n",
+       "MARCKSL1                          0                      0                 0   \n",
+       "SPARC                             0                      0                 0   \n",
+       "\n",
+       "          IRIS_CD4Tcell-N0  IRIS_CD4Tcell-Th1-restimulated12hour  \\\n",
+       "GAS6                     0                                     0   \n",
+       "MMP14                    0                                     0   \n",
+       "DSP                      0                                     0   \n",
+       "MARCKSL1                 0                                     0   \n",
+       "SPARC                    0                                     0   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th1-restimulated48hour  \\\n",
+       "GAS6                                         0   \n",
+       "MMP14                                        0   \n",
+       "DSP                                          0   \n",
+       "MARCKSL1                                     0   \n",
+       "SPARC                                        0   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th2-restimulated12hour  \\\n",
+       "GAS6                                         0   \n",
+       "MMP14                                        0   \n",
+       "DSP                                          0   \n",
+       "MARCKSL1                                     0   \n",
+       "SPARC                                        0   \n",
+       "\n",
+       "          IRIS_CD4Tcell-Th2-restimulated48hour  IRIS_CD8Tcell-N0  \\\n",
+       "GAS6                                         0                 0   \n",
+       "MMP14                                        0                 0   \n",
+       "DSP                                          0                 0   \n",
+       "MARCKSL1                                     0                 0   \n",
+       "SPARC                                        0                 0   \n",
+       "\n",
+       "          IRIS_DendriticCell-Control  ...  KEGG_GNRH_SIGNALING_PATHWAY  \\\n",
+       "GAS6                               1  ...                            0   \n",
+       "MMP14                              0  ...                            1   \n",
+       "DSP                                0  ...                            0   \n",
+       "MARCKSL1                           0  ...                            0   \n",
+       "SPARC                              0  ...                            0   \n",
+       "\n",
+       "          KEGG_BASAL_TRANSCRIPTION_FACTORS  REACTOME_SYNTHESIS_OF_DNA  \\\n",
+       "GAS6                                     0                          0   \n",
+       "MMP14                                    0                          0   \n",
+       "DSP                                      0                          0   \n",
+       "MARCKSL1                                 0                          0   \n",
+       "SPARC                                    0                          0   \n",
+       "\n",
+       "          KEGG_HEMATOPOIETIC_CELL_LINEAGE  \\\n",
+       "GAS6                                    0   \n",
+       "MMP14                                   0   \n",
+       "DSP                                     0   \n",
+       "MARCKSL1                                0   \n",
+       "SPARC                                   0   \n",
+       "\n",
+       "          KEGG_T_CELL_RECEPTOR_SIGNALING_PATHWAY  PID_IL4_2PATHWAY  \\\n",
+       "GAS6                                           0                 0   \n",
+       "MMP14                                          0                 0   \n",
+       "DSP                                            0                 0   \n",
+       "MARCKSL1                                       0                 0   \n",
+       "SPARC                                          0                 0   \n",
+       "\n",
+       "          REACTOME_SIGNALING_BY_THE_B_CELL_RECEPTOR_BCR  PID_BCR_5PATHWAY  \\\n",
+       "GAS6                                                  0                 0   \n",
+       "MMP14                                                 0                 0   \n",
+       "DSP                                                   0                 0   \n",
+       "MARCKSL1                                              0                 0   \n",
+       "SPARC                                                 0                 0   \n",
+       "\n",
+       "          PID_TELOMERASEPATHWAY  PID_PI3KPLCTRKPATHWAY  \n",
+       "GAS6                          0                      0  \n",
+       "MMP14                         0                      0  \n",
+       "DSP                           0                      0  \n",
+       "MARCKSL1                      0                      0  \n",
+       "SPARC                         0                      0  \n",
+       "\n",
+       "[5 rows x 628 columns]"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recount2_all_paths_cm_df.astype(\"int\").head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "papermill": {
+     "duration": 0.74306,
+     "end_time": "2021-07-31T02:45:18.194610",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:17.451550",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "recount2_all_paths_cm_df.astype(\"int\").to_csv(output_text_file, sep=\"\\t\", index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "duration": 0.02695,
+     "end_time": "2021-07-31T02:45:18.315645",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:18.288695",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
+   "formats": "ipynb,py//py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 37.218887,
+   "end_time": "2021-07-31T02:45:20.046262",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "01_preprocessing/005-multiplier_recount2_data.ipynb",
+   "output_path": "01_preprocessing/005-multiplier_recount2_data.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-07-31T02:44:42.827375",
+   "version": "2.2.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
+++ b/nbs/05_preprocessing/10-recount2_multiplier-format.ipynb
@@ -33,7 +33,9 @@
    "source": [
     "This notebook reads 1) the normalized gene expression and 2) pathways from the data processed by\n",
     "MultiPLIER scripts (https://github.com/greenelab/multi-plier) and saves it into a more friendly Python\n",
-    "format (Pandas DataFrames as pickle files)."
+    "format (Pandas DataFrames as pickle files).\n",
+    "\n",
+    "For recount2 we will not perform gene selection as in GTEx, since in this dataset (from MUltiPLIER) we only have ~6,700 genes, which is managable enough to compute the similarity matrices."
    ]
   },
   {
@@ -2909,7 +2911,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f8a298c",
+   "id": "7ad66964-10f5-47f3-9bf7-f70899bd9483",
    "metadata": {
     "papermill": {
      "duration": 0.03321,

--- a/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
+++ b/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
@@ -1,0 +1,237 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     formats: ipynb,py//py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown] tags=[]
+# # Description
+
+# %% [markdown] tags=[]
+# This notebook reads 1) the normalized gene expression and 2) pathways from the data processed by
+# MultiPLIER scripts (https://github.com/greenelab/multi-plier) and saves it into a more friendly Python
+# format (Pandas DataFrames as pickle files).
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %% tags=[]
+import sys
+from pathlib import Path
+from shutil import copyfile
+
+import pandas as pd
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
+from rpy2.robjects.conversion import localconverter
+
+from clustermatch import conf
+
+# %% tags=[]
+readRDS = ro.r["readRDS"]
+
+# %% tags=[]
+saveRDS = ro.r["saveRDS"]
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %% tags=[]
+OUTPUT_DIR = conf.RECOUNT2["DATA_RDS_FILE"].parent
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+display(OUTPUT_DIR)
+
+# %% [markdown] tags=[]
+# # Read entire recount data prep file with R
+
+# %% tags=[]
+display(conf.RECOUNT2["DATA_RDS_FILE"])
+
+if not conf.RECOUNT2["DATA_RDS_FILE"].exists():
+    print("Input file does not exist")
+    sys.exit(0)
+
+# %% tags=[]
+recount_data_prep = readRDS(str(conf.RECOUNT2["DATA_RDS_FILE"]))
+
+# %% [markdown] tags=[]
+# # recount2 gene expression data
+
+# %% [markdown] tags=[]
+# ## Load
+
+# %% tags=[]
+recount2_rpkl_cm = recount_data_prep.rx2("rpkm.cm")
+
+# %% tags=[]
+recount2_rpkl_cm
+
+# %% tags=[]
+recount2_rpkl_cm.rownames
+
+# %% tags=[]
+recount2_rpkl_cm.colnames
+
+# %% tags=[]
+with localconverter(ro.default_converter + pandas2ri.converter):
+    recount2_rpkl_cm = ro.conversion.rpy2py(recount2_rpkl_cm)
+
+# %% tags=[]
+assert recount2_rpkl_cm.shape == (6750, 37032)
+
+# %% tags=[]
+recount2_rpkl_cm.shape
+
+# %% tags=[]
+recount2_rpkl_cm.head()
+
+# %% [markdown] tags=[]
+# ## Test
+
+# %%
+assert not recount2_rpkl_cm.isna().any().any()
+assert recount2_rpkl_cm.index.is_unique
+assert recount2_rpkl_cm.columns.is_unique
+
+# %% [markdown] tags=[]
+# Test whether what I load from a plain R session is the same as in here.
+
+# %% tags=[]
+assert recount2_rpkl_cm.loc["GAS6", "SRP000599.SRR013549"].round(4) == -0.3125
+
+# %% tags=[]
+assert recount2_rpkl_cm.loc["GAS6", "SRP045352.SRR1539229"].round(7) == -0.2843801
+
+# %% tags=[]
+assert recount2_rpkl_cm.loc["CFL2", "SRP056840.SRR1951636"].round(7) == -0.3412832
+
+# %% tags=[]
+assert recount2_rpkl_cm.iloc[9, 16].round(7) == -0.4938852
+
+# %% [markdown] tags=[]
+# ## Save
+
+# %% [markdown] tags=[]
+# ### Pickle format (binary)
+
+# %% tags=[]
+output_filename = conf.RECOUNT2["DATA_FILE"]
+
+display(output_filename)
+
+# %% tags=[]
+recount2_rpkl_cm.to_pickle(output_filename)
+
+# %% tags=[]
+# delete the object to save memory
+del recount2_rpkl_cm
+
+# %% [markdown] tags=[]
+# # recount2 pathways
+
+# %% [markdown] tags=[]
+# ## Load
+
+# %% tags=[]
+recount2_all_paths_cm = recount_data_prep.rx2("all.paths.cm")
+
+# %% tags=[]
+recount2_all_paths_cm
+
+# %% tags=[]
+recount2_all_paths_cm.rownames
+
+# %% tags=[]
+recount2_all_paths_cm.colnames
+
+# %% tags=[]
+with localconverter(ro.default_converter + pandas2ri.converter):
+    recount2_all_paths_cm_values = ro.conversion.rpy2py(recount2_all_paths_cm)
+
+# %% tags=[]
+recount2_all_paths_cm_values
+
+# %% tags=[]
+recount2_all_paths_cm_df = pd.DataFrame(
+    data=recount2_all_paths_cm_values,
+    index=recount2_all_paths_cm.rownames,
+    columns=recount2_all_paths_cm.colnames,
+    dtype=bool,
+)
+
+# %% tags=[]
+assert recount2_all_paths_cm_df.shape == (6750, 628)
+
+# %% tags=[]
+recount2_all_paths_cm_df.shape
+
+# %% tags=[]
+_tmp = recount2_all_paths_cm_df.dtypes.unique()
+display(_tmp)
+assert len(_tmp) == 1
+
+# %% tags=[]
+recount2_all_paths_cm_df.head()
+
+# %% [markdown] tags=[]
+# ## Test
+
+# %% tags=[]
+assert not recount2_all_paths_cm_df.loc[
+    "CTSD", "REACTOME_SCFSKP2_MEDIATED_DEGRADATION_OF_P27_P21"
+]
+
+# %% tags=[]
+assert recount2_all_paths_cm_df.loc["CTSD", "PID_P53DOWNSTREAMPATHWAY"]
+
+# %% tags=[]
+assert recount2_all_paths_cm_df.loc["MMP14", "PID_HIF2PATHWAY"]
+
+# %% [markdown] tags=[]
+# ## Save
+
+# %% [markdown] tags=[]
+# ### Pickle format
+
+# %% tags=[]
+output_filename = conf.RECOUNT2["DATA_FILE"].parent / "recount_all_paths_cm.pkl"
+display(output_filename)
+
+# %% tags=[]
+recount2_all_paths_cm_df.to_pickle(output_filename)
+
+# %% [markdown] tags=[]
+# ### RDS format
+
+# %% tags=[]
+output_rds_file = output_filename.with_suffix(".rds")
+display(output_rds_file)
+
+# %% tags=[]
+saveRDS(recount2_all_paths_cm, str(output_rds_file))
+
+# %% [markdown] tags=[]
+# ### Text format
+
+# %% tags=[]
+# tsv format
+output_text_file = output_filename.with_suffix(".tsv.gz")
+display(output_text_file)
+
+# %% tags=[]
+recount2_all_paths_cm_df.astype("int").head()
+
+# %% tags=[]
+recount2_all_paths_cm_df.astype("int").to_csv(output_text_file, sep="\t", index=True)
+
+# %% tags=[]

--- a/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
+++ b/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
@@ -29,8 +29,6 @@
 
 # %% tags=[]
 import sys
-from pathlib import Path
-from shutil import copyfile
 
 import pandas as pd
 import rpy2.robjects as ro

--- a/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
+++ b/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
@@ -21,6 +21,8 @@
 # This notebook reads 1) the normalized gene expression and 2) pathways from the data processed by
 # MultiPLIER scripts (https://github.com/greenelab/multi-plier) and saves it into a more friendly Python
 # format (Pandas DataFrames as pickle files).
+#
+# For recount2 we will not perform gene selection as in GTEx, since in this dataset (from MUltiPLIER) we only have ~6,700 genes, which is managable enough to compute the similarity matrices.
 
 # %% [markdown] tags=[]
 # # Modules

--- a/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
+++ b/nbs/05_preprocessing/py/10-recount2_multiplier-format.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -98,7 +98,7 @@ recount2_rpkl_cm.head()
 # %% [markdown] tags=[]
 # ## Test
 
-# %%
+# %% tags=[]
 assert not recount2_rpkl_cm.isna().any().any()
 assert recount2_rpkl_cm.index.is_unique
 assert recount2_rpkl_cm.columns.is_unique

--- a/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
@@ -77,7 +77,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from tqdm import tqdm\n",
     "\n",
     "from clustermatch import conf\n",
     "from clustermatch.corr import pearson"
@@ -1153,6 +1152,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b8cd47e2-cf5d-47ae-b2cf-6c1141e7b420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(data_corrs.shape)\n",
+    "\n",
+    "assert data.shape[0] == data_corrs.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6491f65d-18ea-4a86-bde3-988152c1056e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_corrs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
    "metadata": {
@@ -1233,7 +1254,13 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent",
+    "format_version": "1.3",
+    "jupytext_version": "1.11.5"
+   }
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
@@ -5,10 +5,10 @@
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
    "metadata": {
     "papermill": {
-     "duration": 0.042222,
-     "end_time": "2021-09-09T15:54:29.653121",
+     "duration": 0.016805,
+     "end_time": "2021-09-09T17:18:47.095770",
      "exception": false,
-     "start_time": "2021-09-09T15:54:29.610899",
+     "start_time": "2021-09-09T17:18:47.078965",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
    "metadata": {
     "papermill": {
-     "duration": 0.010643,
-     "end_time": "2021-09-09T15:54:29.678078",
+     "duration": 0.012736,
+     "end_time": "2021-09-09T17:18:47.121372",
      "exception": false,
-     "start_time": "2021-09-09T15:54:29.667435",
+     "start_time": "2021-09-09T17:18:47.108636",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.010575,
-     "end_time": "2021-09-09T15:54:29.699463",
+     "duration": 0.01258,
+     "end_time": "2021-09-09T17:18:47.149215",
      "exception": false,
-     "start_time": "2021-09-09T15:54:29.688888",
+     "start_time": "2021-09-09T17:18:47.136635",
      "status": "completed"
     },
     "tags": []
@@ -60,16 +60,16 @@
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:29.728775Z",
-     "iopub.status.busy": "2021-09-09T15:54:29.728296Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.191989Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.191430Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.182164Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.181684Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.656885Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.656380Z"
     },
     "papermill": {
-     "duration": 0.481008,
-     "end_time": "2021-09-09T15:54:30.192096",
+     "duration": 0.494999,
+     "end_time": "2021-09-09T17:18:47.656999",
      "exception": false,
-     "start_time": "2021-09-09T15:54:29.711088",
+     "start_time": "2021-09-09T17:18:47.162000",
      "status": "completed"
     },
     "tags": []
@@ -87,10 +87,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.011218,
-     "end_time": "2021-09-09T15:54:30.214561",
+     "duration": 0.013107,
+     "end_time": "2021-09-09T17:18:47.683643",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.203343",
+     "start_time": "2021-09-09T17:18:47.670536",
      "status": "completed"
     },
     "tags": []
@@ -105,16 +105,16 @@
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.239461Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.239021Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.240684Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.241020Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.713303Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.712830Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.714984Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.714616Z"
     },
     "papermill": {
-     "duration": 0.015683,
-     "end_time": "2021-09-09T15:54:30.241137",
+     "duration": 0.017871,
+     "end_time": "2021-09-09T17:18:47.715081",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.225454",
+     "start_time": "2021-09-09T17:18:47.697210",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.271424Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.270573Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.273977Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.274340Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.749126Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.743092Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.752324Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.751799Z"
     },
     "papermill": {
-     "duration": 0.021704,
-     "end_time": "2021-09-09T15:54:30.274456",
+     "duration": 0.024096,
+     "end_time": "2021-09-09T17:18:47.752419",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.252752",
+     "start_time": "2021-09-09T17:18:47.728323",
      "status": "completed"
     },
     "tags": []
@@ -169,16 +169,16 @@
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.301398Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.300941Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.302499Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.302855Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.782276Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.781824Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.783462Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.783830Z"
     },
     "papermill": {
-     "duration": 0.016571,
-     "end_time": "2021-09-09T15:54:30.302970",
+     "duration": 0.018168,
+     "end_time": "2021-09-09T17:18:47.783994",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.286399",
+     "start_time": "2021-09-09T17:18:47.765826",
      "status": "completed"
     },
     "tags": []
@@ -193,10 +193,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.01127,
-     "end_time": "2021-09-09T15:54:30.325915",
+     "duration": 0.013451,
+     "end_time": "2021-09-09T17:18:47.811313",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.314645",
+     "start_time": "2021-09-09T17:18:47.797862",
      "status": "completed"
     },
     "tags": []
@@ -211,16 +211,16 @@
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.352483Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.351949Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.354730Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.354284Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.841401Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.840838Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.843152Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.843558Z"
     },
     "papermill": {
-     "duration": 0.017673,
-     "end_time": "2021-09-09T15:54:30.354826",
+     "duration": 0.019078,
+     "end_time": "2021-09-09T17:18:47.843674",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.337153",
+     "start_time": "2021-09-09T17:18:47.824596",
      "status": "completed"
     },
     "tags": []
@@ -249,16 +249,16 @@
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.382421Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.381920Z",
-     "iopub.status.idle": "2021-09-09T15:54:30.384871Z",
-     "shell.execute_reply": "2021-09-09T15:54:30.385221Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.875297Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.874710Z",
+     "iopub.status.idle": "2021-09-09T17:18:47.876868Z",
+     "shell.execute_reply": "2021-09-09T17:18:47.877238Z"
     },
     "papermill": {
-     "duration": 0.018273,
-     "end_time": "2021-09-09T15:54:30.385343",
+     "duration": 0.019778,
+     "end_time": "2021-09-09T17:18:47.877353",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.367070",
+     "start_time": "2021-09-09T17:18:47.857575",
      "status": "completed"
     },
     "tags": []
@@ -285,10 +285,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.012702,
-     "end_time": "2021-09-09T15:54:30.411048",
+     "duration": 0.013893,
+     "end_time": "2021-09-09T17:18:47.905434",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.398346",
+     "start_time": "2021-09-09T17:18:47.891541",
      "status": "completed"
     },
     "tags": []
@@ -303,16 +303,16 @@
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:30.438879Z",
-     "iopub.status.busy": "2021-09-09T15:54:30.438410Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.290942Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.291323Z"
+     "iopub.execute_input": "2021-09-09T17:18:47.935816Z",
+     "iopub.status.busy": "2021-09-09T17:18:47.935386Z",
+     "iopub.status.idle": "2021-09-09T17:18:48.827426Z",
+     "shell.execute_reply": "2021-09-09T17:18:48.826900Z"
     },
     "papermill": {
-     "duration": 0.868118,
-     "end_time": "2021-09-09T15:54:31.291458",
+     "duration": 0.908486,
+     "end_time": "2021-09-09T17:18:48.827535",
      "exception": false,
-     "start_time": "2021-09-09T15:54:30.423340",
+     "start_time": "2021-09-09T17:18:47.919049",
      "status": "completed"
     },
     "tags": []
@@ -328,16 +328,16 @@
    "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.320857Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.320204Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.323102Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.322654Z"
+     "iopub.execute_input": "2021-09-09T17:18:48.861171Z",
+     "iopub.status.busy": "2021-09-09T17:18:48.860701Z",
+     "iopub.status.idle": "2021-09-09T17:18:48.863432Z",
+     "shell.execute_reply": "2021-09-09T17:18:48.862967Z"
     },
     "papermill": {
-     "duration": 0.018482,
-     "end_time": "2021-09-09T15:54:31.323197",
+     "duration": 0.020346,
+     "end_time": "2021-09-09T17:18:48.863529",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.304715",
+     "start_time": "2021-09-09T17:18:48.843183",
      "status": "completed"
     },
     "tags": []
@@ -364,16 +364,16 @@
    "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.356805Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.356327Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.374106Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.373692Z"
+     "iopub.execute_input": "2021-09-09T17:18:48.900241Z",
+     "iopub.status.busy": "2021-09-09T17:18:48.899766Z",
+     "iopub.status.idle": "2021-09-09T17:18:48.917864Z",
+     "shell.execute_reply": "2021-09-09T17:18:48.917367Z"
     },
     "papermill": {
-     "duration": 0.037947,
-     "end_time": "2021-09-09T15:54:31.374209",
+     "duration": 0.039565,
+     "end_time": "2021-09-09T17:18:48.917962",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.336262",
+     "start_time": "2021-09-09T17:18:48.878397",
      "status": "completed"
     },
     "tags": []
@@ -616,10 +616,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.01296,
-     "end_time": "2021-09-09T15:54:31.400672",
+     "duration": 0.014331,
+     "end_time": "2021-09-09T17:18:48.947370",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.387712",
+     "start_time": "2021-09-09T17:18:48.933039",
      "status": "completed"
     },
     "tags": []
@@ -633,10 +633,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.013012,
-     "end_time": "2021-09-09T15:54:31.426534",
+     "duration": 0.013921,
+     "end_time": "2021-09-09T17:18:48.975461",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.413522",
+     "start_time": "2021-09-09T17:18:48.961540",
      "status": "completed"
     },
     "tags": []
@@ -651,16 +651,16 @@
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.576930Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.576256Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.579176Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.578660Z"
+     "iopub.execute_input": "2021-09-09T17:18:49.140838Z",
+     "iopub.status.busy": "2021-09-09T17:18:49.140166Z",
+     "iopub.status.idle": "2021-09-09T17:18:49.142594Z",
+     "shell.execute_reply": "2021-09-09T17:18:49.142052Z"
     },
     "papermill": {
-     "duration": 0.139927,
-     "end_time": "2021-09-09T15:54:31.579314",
+     "duration": 0.153135,
+     "end_time": "2021-09-09T17:18:49.142730",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.439387",
+     "start_time": "2021-09-09T17:18:48.989595",
      "status": "completed"
     },
     "tags": []
@@ -677,16 +677,16 @@
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.618472Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.617905Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.620219Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.620646Z"
+     "iopub.execute_input": "2021-09-09T17:18:49.184393Z",
+     "iopub.status.busy": "2021-09-09T17:18:49.183795Z",
+     "iopub.status.idle": "2021-09-09T17:18:49.186578Z",
+     "shell.execute_reply": "2021-09-09T17:18:49.186031Z"
     },
     "papermill": {
-     "duration": 0.023609,
-     "end_time": "2021-09-09T15:54:31.620788",
+     "duration": 0.024524,
+     "end_time": "2021-09-09T17:18:49.186692",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.597179",
+     "start_time": "2021-09-09T17:18:49.162168",
      "status": "completed"
     },
     "tags": []
@@ -713,16 +713,16 @@
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.656369Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.655896Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.671641Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.671201Z"
+     "iopub.execute_input": "2021-09-09T17:18:49.222648Z",
+     "iopub.status.busy": "2021-09-09T17:18:49.222188Z",
+     "iopub.status.idle": "2021-09-09T17:18:49.238190Z",
+     "shell.execute_reply": "2021-09-09T17:18:49.238536Z"
     },
     "papermill": {
-     "duration": 0.034168,
-     "end_time": "2021-09-09T15:54:31.671749",
+     "duration": 0.035123,
+     "end_time": "2021-09-09T17:18:49.238657",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.637581",
+     "start_time": "2021-09-09T17:18:49.203534",
      "status": "completed"
     },
     "tags": []
@@ -965,10 +965,10 @@
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
    "metadata": {
     "papermill": {
-     "duration": 0.013736,
-     "end_time": "2021-09-09T15:54:31.699990",
+     "duration": 0.014832,
+     "end_time": "2021-09-09T17:18:49.269141",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.686254",
+     "start_time": "2021-09-09T17:18:49.254309",
      "status": "completed"
     },
     "tags": []
@@ -983,16 +983,16 @@
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.730705Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.730259Z",
-     "iopub.status.idle": "2021-09-09T15:54:31.740234Z",
-     "shell.execute_reply": "2021-09-09T15:54:31.739766Z"
+     "iopub.execute_input": "2021-09-09T17:18:49.302295Z",
+     "iopub.status.busy": "2021-09-09T17:18:49.301830Z",
+     "iopub.status.idle": "2021-09-09T17:18:49.311945Z",
+     "shell.execute_reply": "2021-09-09T17:18:49.311519Z"
     },
     "papermill": {
-     "duration": 0.026683,
-     "end_time": "2021-09-09T15:54:31.740334",
+     "duration": 0.028116,
+     "end_time": "2021-09-09T17:18:49.312059",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.713651",
+     "start_time": "2021-09-09T17:18:49.283943",
      "status": "completed"
     },
     "tags": []
@@ -1080,16 +1080,16 @@
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:54:31.774289Z",
-     "iopub.status.busy": "2021-09-09T15:54:31.773825Z",
-     "iopub.status.idle": "2021-09-09T15:55:01.467155Z",
-     "shell.execute_reply": "2021-09-09T15:55:01.466642Z"
+     "iopub.execute_input": "2021-09-09T17:18:49.347378Z",
+     "iopub.status.busy": "2021-09-09T17:18:49.346913Z",
+     "iopub.status.idle": "2021-09-09T17:19:18.981729Z",
+     "shell.execute_reply": "2021-09-09T17:19:18.981258Z"
     },
     "papermill": {
-     "duration": 29.712107,
-     "end_time": "2021-09-09T15:55:01.467259",
+     "duration": 29.653803,
+     "end_time": "2021-09-09T17:19:18.981832",
      "exception": false,
-     "start_time": "2021-09-09T15:54:31.755152",
+     "start_time": "2021-09-09T17:18:49.328029",
      "status": "completed"
     },
     "tags": []
@@ -1099,7 +1099,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.71 s ± 7.37 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "3.7 s ± 18.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1112,10 +1112,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.014746,
-     "end_time": "2021-09-09T15:55:01.497883",
+     "duration": 0.015955,
+     "end_time": "2021-09-09T17:19:19.014793",
      "exception": false,
-     "start_time": "2021-09-09T15:55:01.483137",
+     "start_time": "2021-09-09T17:19:18.998838",
      "status": "completed"
     },
     "tags": []
@@ -1130,16 +1130,16 @@
    "id": "189b0295-f968-42b2-9377-a6c404182b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T15:55:01.530619Z",
-     "iopub.status.busy": "2021-09-09T15:55:01.530152Z",
-     "iopub.status.idle": "2021-09-09T16:06:23.999832Z",
-     "shell.execute_reply": "2021-09-09T16:06:23.999233Z"
+     "iopub.execute_input": "2021-09-09T17:19:19.049312Z",
+     "iopub.status.busy": "2021-09-09T17:19:19.048845Z",
+     "iopub.status.idle": "2021-09-09T17:30:39.556335Z",
+     "shell.execute_reply": "2021-09-09T17:30:39.555739Z"
     },
     "papermill": {
-     "duration": 682.487337,
-     "end_time": "2021-09-09T16:06:23.999970",
+     "duration": 680.52604,
+     "end_time": "2021-09-09T17:30:39.556460",
      "exception": false,
-     "start_time": "2021-09-09T15:55:01.512633",
+     "start_time": "2021-09-09T17:19:19.030420",
      "status": "completed"
     },
     "tags": []
@@ -1152,10 +1152,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "b8cd47e2-cf5d-47ae-b2cf-6c1141e7b420",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T17:30:40.495494Z",
+     "iopub.status.busy": "2021-09-09T17:30:40.493607Z",
+     "iopub.status.idle": "2021-09-09T17:30:40.502735Z",
+     "shell.execute_reply": "2021-09-09T17:30:40.501183Z"
+    },
+    "papermill": {
+     "duration": 0.926461,
+     "end_time": "2021-09-09T17:30:40.503115",
+     "exception": false,
+     "start_time": "2021-09-09T17:30:39.576654",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 6750)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(data_corrs.shape)\n",
     "\n",
@@ -1164,30 +1189,252 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "6491f65d-18ea-4a86-bde3-988152c1056e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T17:30:40.580918Z",
+     "iopub.status.busy": "2021-09-09T17:30:40.580258Z",
+     "iopub.status.idle": "2021-09-09T17:30:40.583391Z",
+     "shell.execute_reply": "2021-09-09T17:30:40.582930Z"
+    },
+    "papermill": {
+     "duration": 0.037904,
+     "end_time": "2021-09-09T17:30:40.583489",
+     "exception": false,
+     "start_time": "2021-09-09T17:30:40.545585",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GAS6</th>\n",
+       "      <th>MMP14</th>\n",
+       "      <th>DSP</th>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <th>SPARC</th>\n",
+       "      <th>CTSD</th>\n",
+       "      <th>EPAS1</th>\n",
+       "      <th>PALLD</th>\n",
+       "      <th>PHC2</th>\n",
+       "      <th>LGALS3BP</th>\n",
+       "      <th>...</th>\n",
+       "      <th>LDHB</th>\n",
+       "      <th>LDHC</th>\n",
+       "      <th>ACAP2</th>\n",
+       "      <th>ACAP3</th>\n",
+       "      <th>CFL2</th>\n",
+       "      <th>CFL1</th>\n",
+       "      <th>NFIB</th>\n",
+       "      <th>PLEKHG6</th>\n",
+       "      <th>GNGT2</th>\n",
+       "      <th>SERPINH1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.294974</td>\n",
+       "      <td>0.056459</td>\n",
+       "      <td>-0.025141</td>\n",
+       "      <td>0.200635</td>\n",
+       "      <td>0.103548</td>\n",
+       "      <td>0.131867</td>\n",
+       "      <td>0.276463</td>\n",
+       "      <td>0.112967</td>\n",
+       "      <td>0.130925</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.056567</td>\n",
+       "      <td>-0.007278</td>\n",
+       "      <td>-0.030214</td>\n",
+       "      <td>0.148051</td>\n",
+       "      <td>0.039434</td>\n",
+       "      <td>0.047084</td>\n",
+       "      <td>-0.029201</td>\n",
+       "      <td>0.028263</td>\n",
+       "      <td>-0.010433</td>\n",
+       "      <td>0.386991</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>0.294974</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.055232</td>\n",
+       "      <td>0.019443</td>\n",
+       "      <td>0.162131</td>\n",
+       "      <td>0.288713</td>\n",
+       "      <td>0.078418</td>\n",
+       "      <td>0.152664</td>\n",
+       "      <td>0.200287</td>\n",
+       "      <td>0.230657</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.075008</td>\n",
+       "      <td>-0.017159</td>\n",
+       "      <td>-0.022373</td>\n",
+       "      <td>0.195568</td>\n",
+       "      <td>-0.008378</td>\n",
+       "      <td>0.060350</td>\n",
+       "      <td>-0.035702</td>\n",
+       "      <td>0.019021</td>\n",
+       "      <td>-0.001449</td>\n",
+       "      <td>0.348298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>0.056459</td>\n",
+       "      <td>0.055232</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>-0.036595</td>\n",
+       "      <td>0.035897</td>\n",
+       "      <td>0.040336</td>\n",
+       "      <td>0.044387</td>\n",
+       "      <td>0.141760</td>\n",
+       "      <td>-0.023011</td>\n",
+       "      <td>0.027952</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.052872</td>\n",
+       "      <td>-0.010162</td>\n",
+       "      <td>0.033149</td>\n",
+       "      <td>0.003191</td>\n",
+       "      <td>-0.025231</td>\n",
+       "      <td>-0.019664</td>\n",
+       "      <td>-0.020029</td>\n",
+       "      <td>0.135147</td>\n",
+       "      <td>-0.017221</td>\n",
+       "      <td>0.061731</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>-0.025141</td>\n",
+       "      <td>0.019443</td>\n",
+       "      <td>-0.036595</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.029414</td>\n",
+       "      <td>-0.003729</td>\n",
+       "      <td>-0.030208</td>\n",
+       "      <td>0.018872</td>\n",
+       "      <td>0.130432</td>\n",
+       "      <td>0.022778</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.069346</td>\n",
+       "      <td>-0.003312</td>\n",
+       "      <td>-0.015761</td>\n",
+       "      <td>0.201729</td>\n",
+       "      <td>-0.022687</td>\n",
+       "      <td>0.018768</td>\n",
+       "      <td>0.024176</td>\n",
+       "      <td>0.027592</td>\n",
+       "      <td>0.004332</td>\n",
+       "      <td>0.146742</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>0.200635</td>\n",
+       "      <td>0.162131</td>\n",
+       "      <td>0.035897</td>\n",
+       "      <td>0.029414</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>-0.007102</td>\n",
+       "      <td>0.079556</td>\n",
+       "      <td>0.278528</td>\n",
+       "      <td>0.028905</td>\n",
+       "      <td>0.089256</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.084137</td>\n",
+       "      <td>-0.009165</td>\n",
+       "      <td>-0.058129</td>\n",
+       "      <td>-0.005859</td>\n",
+       "      <td>0.102020</td>\n",
+       "      <td>0.077243</td>\n",
+       "      <td>-0.020692</td>\n",
+       "      <td>-0.009489</td>\n",
+       "      <td>-0.016504</td>\n",
+       "      <td>0.412960</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 6750 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              GAS6     MMP14       DSP  MARCKSL1     SPARC      CTSD  \\\n",
+       "GAS6      1.000000  0.294974  0.056459 -0.025141  0.200635  0.103548   \n",
+       "MMP14     0.294974  1.000000  0.055232  0.019443  0.162131  0.288713   \n",
+       "DSP       0.056459  0.055232  1.000000 -0.036595  0.035897  0.040336   \n",
+       "MARCKSL1 -0.025141  0.019443 -0.036595  1.000000  0.029414 -0.003729   \n",
+       "SPARC     0.200635  0.162131  0.035897  0.029414  1.000000 -0.007102   \n",
+       "\n",
+       "             EPAS1     PALLD      PHC2  LGALS3BP  ...      LDHB      LDHC  \\\n",
+       "GAS6      0.131867  0.276463  0.112967  0.130925  ... -0.056567 -0.007278   \n",
+       "MMP14     0.078418  0.152664  0.200287  0.230657  ... -0.075008 -0.017159   \n",
+       "DSP       0.044387  0.141760 -0.023011  0.027952  ... -0.052872 -0.010162   \n",
+       "MARCKSL1 -0.030208  0.018872  0.130432  0.022778  ...  0.069346 -0.003312   \n",
+       "SPARC     0.079556  0.278528  0.028905  0.089256  ...  0.084137 -0.009165   \n",
+       "\n",
+       "             ACAP2     ACAP3      CFL2      CFL1      NFIB   PLEKHG6  \\\n",
+       "GAS6     -0.030214  0.148051  0.039434  0.047084 -0.029201  0.028263   \n",
+       "MMP14    -0.022373  0.195568 -0.008378  0.060350 -0.035702  0.019021   \n",
+       "DSP       0.033149  0.003191 -0.025231 -0.019664 -0.020029  0.135147   \n",
+       "MARCKSL1 -0.015761  0.201729 -0.022687  0.018768  0.024176  0.027592   \n",
+       "SPARC    -0.058129 -0.005859  0.102020  0.077243 -0.020692 -0.009489   \n",
+       "\n",
+       "             GNGT2  SERPINH1  \n",
+       "GAS6     -0.010433  0.386991  \n",
+       "MMP14    -0.001449  0.348298  \n",
+       "DSP      -0.017221  0.061731  \n",
+       "MARCKSL1  0.004332  0.146742  \n",
+       "SPARC    -0.016504  0.412960  \n",
+       "\n",
+       "[5 rows x 6750 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data_corrs.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:24.945387Z",
-     "iopub.status.busy": "2021-09-09T16:06:24.943460Z",
-     "iopub.status.idle": "2021-09-09T16:06:24.950871Z",
-     "shell.execute_reply": "2021-09-09T16:06:24.952364Z"
+     "iopub.execute_input": "2021-09-09T17:30:40.621934Z",
+     "iopub.status.busy": "2021-09-09T17:30:40.621380Z",
+     "iopub.status.idle": "2021-09-09T17:30:40.624299Z",
+     "shell.execute_reply": "2021-09-09T17:30:40.623809Z"
     },
     "papermill": {
-     "duration": 0.932341,
-     "end_time": "2021-09-09T16:06:24.952828",
+     "duration": 0.023323,
+     "end_time": "2021-09-09T17:30:40.624395",
      "exception": false,
-     "start_time": "2021-09-09T16:06:24.020487",
+     "start_time": "2021-09-09T17:30:40.601072",
      "status": "completed"
     },
     "tags": []
@@ -1210,20 +1457,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:25.015956Z",
-     "iopub.status.busy": "2021-09-09T16:06:25.014720Z",
-     "iopub.status.idle": "2021-09-09T16:06:25.209917Z",
-     "shell.execute_reply": "2021-09-09T16:06:25.209404Z"
+     "iopub.execute_input": "2021-09-09T17:30:40.661967Z",
+     "iopub.status.busy": "2021-09-09T17:30:40.661506Z",
+     "iopub.status.idle": "2021-09-09T17:30:42.613522Z",
+     "shell.execute_reply": "2021-09-09T17:30:42.610999Z"
     },
     "papermill": {
-     "duration": 0.214429,
-     "end_time": "2021-09-09T16:06:25.210024",
+     "duration": 1.972041,
+     "end_time": "2021-09-09T17:30:42.613906",
      "exception": false,
-     "start_time": "2021-09-09T16:06:24.995595",
+     "start_time": "2021-09-09T17:30:40.641865",
      "status": "completed"
     },
     "tags": []
@@ -1240,10 +1487,10 @@
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
    "metadata": {
     "papermill": {
-     "duration": 0.016034,
-     "end_time": "2021-09-09T16:06:25.243034",
+     "duration": 0.017949,
+     "end_time": "2021-09-09T17:30:42.678453",
      "exception": false,
-     "start_time": "2021-09-09T16:06:25.227000",
+     "start_time": "2021-09-09T17:30:42.660504",
      "status": "completed"
     },
     "tags": []
@@ -1254,13 +1501,7 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1281,14 +1522,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 717.016045,
-   "end_time": "2021-09-09T16:06:25.566395",
+   "duration": 716.991036,
+   "end_time": "2021-09-09T17:30:43.004539",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb",
    "output_path": "nbs/10_compute_correlations/10_recount2/05-recount2-pearson.run.ipynb",
    "parameters": {},
-   "start_time": "2021-09-09T15:54:28.550350",
+   "start_time": "2021-09-09T17:18:46.013503",
    "version": "2.3.3"
   },
   "toc-autonumbering": true

--- a/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
@@ -5,10 +5,10 @@
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
    "metadata": {
     "papermill": {
-     "duration": 0.010569,
-     "end_time": "2021-09-01T16:47:37.867743",
+     "duration": 0.042222,
+     "end_time": "2021-09-09T15:54:29.653121",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.857174",
+     "start_time": "2021-09-09T15:54:29.610899",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
    "metadata": {
     "papermill": {
-     "duration": 0.00983,
-     "end_time": "2021-09-01T16:47:37.887716",
+     "duration": 0.010643,
+     "end_time": "2021-09-09T15:54:29.678078",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.877886",
+     "start_time": "2021-09-09T15:54:29.667435",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.011029,
-     "end_time": "2021-09-01T16:47:37.909510",
+     "duration": 0.010575,
+     "end_time": "2021-09-09T15:54:29.699463",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.898481",
+     "start_time": "2021-09-09T15:54:29.688888",
      "status": "completed"
     },
     "tags": []
@@ -56,14 +56,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:29.728775Z",
+     "iopub.status.busy": "2021-09-09T15:54:29.728296Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.191989Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.191430Z"
+    },
     "papermill": {
-     "duration": 0.676691,
-     "end_time": "2021-09-01T16:47:38.596938",
+     "duration": 0.481008,
+     "end_time": "2021-09-09T15:54:30.192096",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.920247",
+     "start_time": "2021-09-09T15:54:29.711088",
      "status": "completed"
     },
     "tags": []
@@ -82,10 +88,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.010086,
-     "end_time": "2021-09-01T16:47:38.618172",
+     "duration": 0.011218,
+     "end_time": "2021-09-09T15:54:30.214561",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.608086",
+     "start_time": "2021-09-09T15:54:30.203343",
      "status": "completed"
     },
     "tags": []
@@ -96,14 +102,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.239461Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.239021Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.240684Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.241020Z"
+    },
     "papermill": {
-     "duration": 0.015995,
-     "end_time": "2021-09-01T16:47:38.644456",
+     "duration": 0.015683,
+     "end_time": "2021-09-09T15:54:30.241137",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.628461",
+     "start_time": "2021-09-09T15:54:30.225454",
      "status": "completed"
     },
     "tags": []
@@ -116,19 +128,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.271424Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.270573Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.273977Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.274340Z"
+    },
     "papermill": {
-     "duration": 0.023325,
-     "end_time": "2021-09-01T16:47:38.678642",
+     "duration": 0.021704,
+     "end_time": "2021-09-09T15:54:30.274456",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.655317",
+     "start_time": "2021-09-09T15:54:30.252752",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'pearson'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CORRELATION_METHOD = pearson\n",
     "\n",
@@ -138,14 +166,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.301398Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.300941Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.302499Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.302855Z"
+    },
     "papermill": {
-     "duration": 0.017081,
-     "end_time": "2021-09-01T16:47:38.707224",
+     "duration": 0.016571,
+     "end_time": "2021-09-09T15:54:30.302970",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.690143",
+     "start_time": "2021-09-09T15:54:30.286399",
      "status": "completed"
     },
     "tags": []
@@ -160,10 +194,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.010528,
-     "end_time": "2021-09-01T16:47:38.728618",
+     "duration": 0.01127,
+     "end_time": "2021-09-09T15:54:30.325915",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.718090",
+     "start_time": "2021-09-09T15:54:30.314645",
      "status": "completed"
     },
     "tags": []
@@ -174,19 +208,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.352483Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.351949Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.354730Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.354284Z"
+    },
     "papermill": {
-     "duration": 0.017698,
-     "end_time": "2021-09-01T16:47:38.757393",
+     "duration": 0.017673,
+     "end_time": "2021-09-09T15:54:30.354826",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.739695",
+     "start_time": "2021-09-09T15:54:30.337153",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/data/recount2/recount_data_prep_PLIER.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "INPUT_FILE = conf.RECOUNT2[\"DATA_FILE\"]\n",
     "display(INPUT_FILE)\n",
@@ -196,19 +246,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.382421Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.381920Z",
+     "iopub.status.idle": "2021-09-09T15:54:30.384871Z",
+     "shell.execute_reply": "2021-09-09T15:54:30.385221Z"
+    },
     "papermill": {
-     "duration": 0.019595,
-     "end_time": "2021-09-01T16:47:38.788047",
+     "duration": 0.018273,
+     "end_time": "2021-09-09T15:54:30.385343",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.768452",
+     "start_time": "2021-09-09T15:54:30.367070",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/recount2/similarity_matrices')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "OUTPUT_DIR = conf.RECOUNT2[\"SIMILARITY_MATRICES_DIR\"]\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
@@ -220,10 +286,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.011293,
-     "end_time": "2021-09-01T16:47:38.811314",
+     "duration": 0.012702,
+     "end_time": "2021-09-09T15:54:30.411048",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.800021",
+     "start_time": "2021-09-09T15:54:30.398346",
      "status": "completed"
     },
     "tags": []
@@ -234,14 +300,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:30.438879Z",
+     "iopub.status.busy": "2021-09-09T15:54:30.438410Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.290942Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.291323Z"
+    },
     "papermill": {
-     "duration": 0.020006,
-     "end_time": "2021-09-01T16:47:38.843018",
+     "duration": 0.868118,
+     "end_time": "2021-09-09T15:54:31.291458",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.823012",
+     "start_time": "2021-09-09T15:54:30.423340",
      "status": "completed"
     },
     "tags": []
@@ -253,20 +325,289 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.320857Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.320204Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.323102Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.322654Z"
+    },
+    "papermill": {
+     "duration": 0.018482,
+     "end_time": "2021-09-09T15:54:31.323197",
+     "exception": false,
+     "start_time": "2021-09-09T15:54:31.304715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 37032)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.356805Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.356327Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.374106Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.373692Z"
+    },
+    "papermill": {
+     "duration": 0.037947,
+     "end_time": "2021-09-09T15:54:31.374209",
+     "exception": false,
+     "start_time": "2021-09-09T15:54:31.336262",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SRP000599.SRR013549</th>\n",
+       "      <th>SRP000599.SRR013550</th>\n",
+       "      <th>SRP000599.SRR013551</th>\n",
+       "      <th>SRP000599.SRR013552</th>\n",
+       "      <th>SRP000599.SRR013553</th>\n",
+       "      <th>SRP000599.SRR013554</th>\n",
+       "      <th>SRP000599.SRR013555</th>\n",
+       "      <th>SRP000599.SRR013556</th>\n",
+       "      <th>SRP000599.SRR013557</th>\n",
+       "      <th>SRP000599.SRR013558</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SRP035599.SRR1139372</th>\n",
+       "      <th>SRP035599.SRR1139393</th>\n",
+       "      <th>SRP035599.SRR1139388</th>\n",
+       "      <th>SRP035599.SRR1139378</th>\n",
+       "      <th>SRP035599.SRR1139399</th>\n",
+       "      <th>SRP035599.SRR1139386</th>\n",
+       "      <th>SRP035599.SRR1139375</th>\n",
+       "      <th>SRP035599.SRR1139382</th>\n",
+       "      <th>SRP035599.SRR1139356</th>\n",
+       "      <th>SRP035599.SRR1139370</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>-0.312500</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.308253</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.301711</td>\n",
+       "      <td>-0.305581</td>\n",
+       "      <td>-0.303344</td>\n",
+       "      <td>-0.297800</td>\n",
+       "      <td>-0.307122</td>\n",
+       "      <td>-0.285499</td>\n",
+       "      <td>-0.309599</td>\n",
+       "      <td>-0.300220</td>\n",
+       "      <td>-0.297667</td>\n",
+       "      <td>-0.310151</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.325140</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.314587</td>\n",
+       "      <td>-0.322952</td>\n",
+       "      <td>-0.326439</td>\n",
+       "      <td>-0.325994</td>\n",
+       "      <td>-0.326272</td>\n",
+       "      <td>-0.322523</td>\n",
+       "      <td>-0.326375</td>\n",
+       "      <td>-0.326339</td>\n",
+       "      <td>-0.322127</td>\n",
+       "      <td>-0.327438</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>-0.286319</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.277195</td>\n",
+       "      <td>-0.256862</td>\n",
+       "      <td>-0.278790</td>\n",
+       "      <td>-0.269701</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286745</td>\n",
+       "      <td>-0.286688</td>\n",
+       "      <td>-0.286725</td>\n",
+       "      <td>-0.286529</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286671</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.807663</td>\n",
+       "      <td>1.294564</td>\n",
+       "      <td>1.527655</td>\n",
+       "      <td>1.404788</td>\n",
+       "      <td>1.047931</td>\n",
+       "      <td>0.892119</td>\n",
+       "      <td>1.507099</td>\n",
+       "      <td>2.458255</td>\n",
+       "      <td>2.919662</td>\n",
+       "      <td>1.410846</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.369171</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.345409</td>\n",
+       "      <td>-0.310750</td>\n",
+       "      <td>-0.348120</td>\n",
+       "      <td>-0.356938</td>\n",
+       "      <td>-0.355206</td>\n",
+       "      <td>-0.366197</td>\n",
+       "      <td>-0.351174</td>\n",
+       "      <td>-0.363703</td>\n",
+       "      <td>-0.350825</td>\n",
+       "      <td>-0.360762</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 37032 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          SRP000599.SRR013549  SRP000599.SRR013550  SRP000599.SRR013551  \\\n",
+       "GAS6                -0.312500            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286319            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.369171   \n",
+       "\n",
+       "          SRP000599.SRR013552  SRP000599.SRR013553  SRP000599.SRR013554  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.308253   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286859            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013555  SRP000599.SRR013556  SRP000599.SRR013557  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.277195            -0.256862            -0.278790   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013558  ...  SRP035599.SRR1139372  \\\n",
+       "GAS6                -0.312931  ...             -0.301711   \n",
+       "MMP14               -0.325140  ...             -0.314587   \n",
+       "DSP                 -0.269701  ...             -0.286859   \n",
+       "MARCKSL1            -0.536646  ...              0.807663   \n",
+       "SPARC               -0.370498  ...             -0.345409   \n",
+       "\n",
+       "          SRP035599.SRR1139393  SRP035599.SRR1139388  SRP035599.SRR1139378  \\\n",
+       "GAS6                 -0.305581             -0.303344             -0.297800   \n",
+       "MMP14                -0.322952             -0.326439             -0.325994   \n",
+       "DSP                  -0.286859             -0.286745             -0.286688   \n",
+       "MARCKSL1              1.294564              1.527655              1.404788   \n",
+       "SPARC                -0.310750             -0.348120             -0.356938   \n",
+       "\n",
+       "          SRP035599.SRR1139399  SRP035599.SRR1139386  SRP035599.SRR1139375  \\\n",
+       "GAS6                 -0.307122             -0.285499             -0.309599   \n",
+       "MMP14                -0.326272             -0.322523             -0.326375   \n",
+       "DSP                  -0.286725             -0.286529             -0.286859   \n",
+       "MARCKSL1              1.047931              0.892119              1.507099   \n",
+       "SPARC                -0.355206             -0.366197             -0.351174   \n",
+       "\n",
+       "          SRP035599.SRR1139382  SRP035599.SRR1139356  SRP035599.SRR1139370  \n",
+       "GAS6                 -0.300220             -0.297667             -0.310151  \n",
+       "MMP14                -0.326339             -0.322127             -0.327438  \n",
+       "DSP                  -0.286671             -0.286859             -0.286740  \n",
+       "MARCKSL1              2.458255              2.919662              1.410846  \n",
+       "SPARC                -0.363703             -0.350825             -0.360762  \n",
+       "\n",
+       "[5 rows x 37032 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data.head()"
    ]
@@ -276,10 +617,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.013359,
-     "end_time": "2021-09-01T16:47:38.868909",
+     "duration": 0.01296,
+     "end_time": "2021-09-09T15:54:31.400672",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.855550",
+     "start_time": "2021-09-09T15:54:31.387712",
      "status": "completed"
     },
     "tags": []
@@ -293,10 +634,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.013364,
-     "end_time": "2021-09-01T16:47:38.895699",
+     "duration": 0.013012,
+     "end_time": "2021-09-09T15:54:31.426534",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.882335",
+     "start_time": "2021-09-09T15:54:31.413522",
      "status": "completed"
     },
     "tags": []
@@ -307,14 +648,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.576930Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.576256Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.579176Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.578660Z"
+    },
     "papermill": {
-     "duration": 0.032647,
-     "end_time": "2021-09-01T16:47:38.942409",
+     "duration": 0.139927,
+     "end_time": "2021-09-09T15:54:31.579314",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.909762",
+     "start_time": "2021-09-09T15:54:31.439387",
      "status": "completed"
     },
     "tags": []
@@ -327,38 +674,289 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.618472Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.617905Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.620219Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.620646Z"
+    },
     "papermill": {
-     "duration": 0.019586,
-     "end_time": "2021-09-01T16:47:38.975115",
+     "duration": 0.023609,
+     "end_time": "2021-09-09T15:54:31.620788",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.955529",
+     "start_time": "2021-09-09T15:54:31.597179",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(500, 37032)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.656369Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.655896Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.671641Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.671201Z"
+    },
     "papermill": {
-     "duration": 0.043426,
-     "end_time": "2021-09-01T16:47:39.031725",
+     "duration": 0.034168,
+     "end_time": "2021-09-09T15:54:31.671749",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.988299",
+     "start_time": "2021-09-09T15:54:31.637581",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SRP000599.SRR013549</th>\n",
+       "      <th>SRP000599.SRR013550</th>\n",
+       "      <th>SRP000599.SRR013551</th>\n",
+       "      <th>SRP000599.SRR013552</th>\n",
+       "      <th>SRP000599.SRR013553</th>\n",
+       "      <th>SRP000599.SRR013554</th>\n",
+       "      <th>SRP000599.SRR013555</th>\n",
+       "      <th>SRP000599.SRR013556</th>\n",
+       "      <th>SRP000599.SRR013557</th>\n",
+       "      <th>SRP000599.SRR013558</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SRP035599.SRR1139372</th>\n",
+       "      <th>SRP035599.SRR1139393</th>\n",
+       "      <th>SRP035599.SRR1139388</th>\n",
+       "      <th>SRP035599.SRR1139378</th>\n",
+       "      <th>SRP035599.SRR1139399</th>\n",
+       "      <th>SRP035599.SRR1139386</th>\n",
+       "      <th>SRP035599.SRR1139375</th>\n",
+       "      <th>SRP035599.SRR1139382</th>\n",
+       "      <th>SRP035599.SRR1139356</th>\n",
+       "      <th>SRP035599.SRR1139370</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>S1PR5</th>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.261464</td>\n",
+       "      <td>-0.262521</td>\n",
+       "      <td>-0.263571</td>\n",
+       "      <td>-0.232207</td>\n",
+       "      <td>-0.263313</td>\n",
+       "      <td>-0.263926</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.264052</td>\n",
+       "      <td>0.141801</td>\n",
+       "      <td>-0.101283</td>\n",
+       "      <td>0.016574</td>\n",
+       "      <td>0.054545</td>\n",
+       "      <td>0.109291</td>\n",
+       "      <td>-0.080455</td>\n",
+       "      <td>-0.039797</td>\n",
+       "      <td>-0.171493</td>\n",
+       "      <td>-0.039619</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EXOSC10</th>\n",
+       "      <td>-0.775256</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.151619</td>\n",
+       "      <td>-0.190753</td>\n",
+       "      <td>-0.263083</td>\n",
+       "      <td>0.006409</td>\n",
+       "      <td>-0.090697</td>\n",
+       "      <td>-0.196750</td>\n",
+       "      <td>-0.039938</td>\n",
+       "      <td>0.155149</td>\n",
+       "      <td>0.076707</td>\n",
+       "      <td>0.201055</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ALOX15B</th>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.102583</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.090938</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.091455</td>\n",
+       "      <td>-0.097841</td>\n",
+       "      <td>-0.097053</td>\n",
+       "      <td>-0.098525</td>\n",
+       "      <td>-0.102490</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CACNB1</th>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.002829</td>\n",
+       "      <td>-0.176210</td>\n",
+       "      <td>-0.124728</td>\n",
+       "      <td>-0.034000</td>\n",
+       "      <td>-0.170579</td>\n",
+       "      <td>-0.134903</td>\n",
+       "      <td>-0.050322</td>\n",
+       "      <td>-0.160912</td>\n",
+       "      <td>-0.034017</td>\n",
+       "      <td>-0.001866</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 37032 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         SRP000599.SRR013549  SRP000599.SRR013550  SRP000599.SRR013551  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.775256            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013552  SRP000599.SRR013553  SRP000599.SRR013554  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.781191            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013555  SRP000599.SRR013556  SRP000599.SRR013557  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.781191            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013558  ...  SRP035599.SRR1139372  SRP035599.SRR1139393  \\\n",
+       "S1PR5              -0.266852  ...             -0.266852             -0.266852   \n",
+       "NDUFA12            -0.389020  ...              0.264052              0.141801   \n",
+       "EXOSC10            -0.781191  ...             -0.151619             -0.190753   \n",
+       "ALOX15B            -0.104175  ...             -0.102583             -0.104175   \n",
+       "CACNB1             -0.412386  ...             -0.002829             -0.176210   \n",
+       "\n",
+       "         SRP035599.SRR1139388  SRP035599.SRR1139378  SRP035599.SRR1139399  \\\n",
+       "S1PR5               -0.261464             -0.262521             -0.263571   \n",
+       "NDUFA12             -0.101283              0.016574              0.054545   \n",
+       "EXOSC10             -0.263083              0.006409             -0.090697   \n",
+       "ALOX15B             -0.104175             -0.090938             -0.104175   \n",
+       "CACNB1              -0.124728             -0.034000             -0.170579   \n",
+       "\n",
+       "         SRP035599.SRR1139386  SRP035599.SRR1139375  SRP035599.SRR1139382  \\\n",
+       "S1PR5               -0.232207             -0.263313             -0.263926   \n",
+       "NDUFA12              0.109291             -0.080455             -0.039797   \n",
+       "EXOSC10             -0.196750             -0.039938              0.155149   \n",
+       "ALOX15B             -0.091455             -0.097841             -0.097053   \n",
+       "CACNB1              -0.134903             -0.050322             -0.160912   \n",
+       "\n",
+       "         SRP035599.SRR1139356  SRP035599.SRR1139370  \n",
+       "S1PR5               -0.266852             -0.266852  \n",
+       "NDUFA12             -0.171493             -0.039619  \n",
+       "EXOSC10              0.076707              0.201055  \n",
+       "ALOX15B             -0.098525             -0.102490  \n",
+       "CACNB1              -0.034017             -0.001866  \n",
+       "\n",
+       "[5 rows x 37032 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.head()"
    ]
@@ -368,10 +966,10 @@
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
    "metadata": {
     "papermill": {
-     "duration": 0.015078,
-     "end_time": "2021-09-01T16:47:39.061229",
+     "duration": 0.013736,
+     "end_time": "2021-09-09T15:54:31.699990",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.046151",
+     "start_time": "2021-09-09T15:54:31.686254",
      "status": "completed"
     },
     "tags": []
@@ -382,19 +980,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.730705Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.730259Z",
+     "iopub.status.idle": "2021-09-09T15:54:31.740234Z",
+     "shell.execute_reply": "2021-09-09T15:54:31.739766Z"
+    },
     "papermill": {
-     "duration": 0.027224,
-     "end_time": "2021-09-01T16:47:39.102873",
+     "duration": 0.026683,
+     "end_time": "2021-09-09T15:54:31.740334",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.075649",
+     "start_time": "2021-09-09T15:54:31.713651",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 3)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>S1PR5</th>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <th>EXOSC10</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>S1PR5</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>-0.029604</td>\n",
+       "      <td>-0.001391</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <td>-0.029604</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.061790</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EXOSC10</th>\n",
+       "      <td>-0.001391</td>\n",
+       "      <td>0.061790</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            S1PR5   NDUFA12   EXOSC10\n",
+       "S1PR5    1.000000 -0.029604 -0.001391\n",
+       "NDUFA12 -0.029604  1.000000  0.061790\n",
+       "EXOSC10 -0.001391  0.061790  1.000000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
     "\n",
@@ -404,19 +1077,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:54:31.774289Z",
+     "iopub.status.busy": "2021-09-09T15:54:31.773825Z",
+     "iopub.status.idle": "2021-09-09T15:55:01.467155Z",
+     "shell.execute_reply": "2021-09-09T15:55:01.466642Z"
+    },
     "papermill": {
-     "duration": 4.568251,
-     "end_time": "2021-09-01T16:47:43.686520",
+     "duration": 29.712107,
+     "end_time": "2021-09-09T15:55:01.467259",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.118269",
+     "start_time": "2021-09-09T15:54:31.755152",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.71 s ± 7.37 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit CORRELATION_METHOD(test_data)"
    ]
@@ -426,10 +1113,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.015392,
-     "end_time": "2021-09-01T16:47:43.716801",
+     "duration": 0.014746,
+     "end_time": "2021-09-09T15:55:01.497883",
      "exception": false,
-     "start_time": "2021-09-01T16:47:43.701409",
+     "start_time": "2021-09-09T15:55:01.483137",
      "status": "completed"
     },
     "tags": []
@@ -440,9 +1127,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "189b0295-f968-42b2-9377-a6c404182b01",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T15:55:01.530619Z",
+     "iopub.status.busy": "2021-09-09T15:55:01.530152Z",
+     "iopub.status.idle": "2021-09-09T16:06:23.999832Z",
+     "shell.execute_reply": "2021-09-09T16:06:23.999233Z"
+    },
+    "papermill": {
+     "duration": 682.487337,
+     "end_time": "2021-09-09T16:06:23.999970",
+     "exception": false,
+     "start_time": "2021-09-09T15:55:01.512633",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# compute correlations\n",
@@ -451,10 +1153,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:24.945387Z",
+     "iopub.status.busy": "2021-09-09T16:06:24.943460Z",
+     "iopub.status.idle": "2021-09-09T16:06:24.950871Z",
+     "shell.execute_reply": "2021-09-09T16:06:24.952364Z"
+    },
+    "papermill": {
+     "duration": 0.932341,
+     "end_time": "2021-09-09T16:06:24.952828",
+     "exception": false,
+     "start_time": "2021-09-09T16:06:24.020487",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/recount2/similarity_matrices/recount_data_prep_PLIER-pearson.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "output_filename = OUTPUT_DIR / f\"{INPUT_FILE.stem}-{method_name}.pkl\"\n",
     "display(output_filename)"
@@ -462,9 +1189,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:25.015956Z",
+     "iopub.status.busy": "2021-09-09T16:06:25.014720Z",
+     "iopub.status.idle": "2021-09-09T16:06:25.209917Z",
+     "shell.execute_reply": "2021-09-09T16:06:25.209404Z"
+    },
+    "papermill": {
+     "duration": 0.214429,
+     "end_time": "2021-09-09T16:06:25.210024",
+     "exception": false,
+     "start_time": "2021-09-09T16:06:24.995595",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# save\n",
@@ -477,10 +1219,10 @@
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
    "metadata": {
     "papermill": {
-     "duration": 0.035801,
-     "end_time": "2021-09-01T16:50:25.296220",
+     "duration": 0.016034,
+     "end_time": "2021-09-09T16:06:25.243034",
      "exception": false,
-     "start_time": "2021-09-01T16:50:25.260419",
+     "start_time": "2021-09-09T16:06:25.227000",
      "status": "completed"
     },
     "tags": []
@@ -508,18 +1250,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 168.556635,
-   "end_time": "2021-09-01T16:50:25.542183",
+   "duration": 717.016045,
+   "end_time": "2021-09-09T16:06:25.566395",
    "environment_variables": {},
    "exception": null,
-   "input_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb",
-   "output_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.run.ipynb",
+   "input_path": "nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb",
+   "output_path": "nbs/10_compute_correlations/10_recount2/05-recount2-pearson.run.ipynb",
    "parameters": {},
-   "start_time": "2021-09-01T16:47:36.985548",
+   "start_time": "2021-09-09T15:54:28.550350",
    "version": "2.3.3"
   },
   "toc-autonumbering": true

--- a/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/05-recount2-pearson.ipynb
@@ -1,0 +1,529 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010569,
+     "end_time": "2021-09-01T16:47:37.867743",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.857174",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00983,
+     "end_time": "2021-09-01T16:47:37.887716",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.877886",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "According to the settings specified below, this notebook:\n",
+    " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
+    " 2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and\n",
+    " 3. computes the correlation matrix across all the genes using the correlation coefficient specified."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011029,
+     "end_time": "2021-09-01T16:47:37.909510",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.898481",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.676691,
+     "end_time": "2021-09-01T16:47:38.596938",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.920247",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from clustermatch import conf\n",
+    "from clustermatch.corr import pearson"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010086,
+     "end_time": "2021-09-01T16:47:38.618172",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.608086",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56ff94d3-a230-4028-a71d-518ac109209b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015995,
+     "end_time": "2021-09-01T16:47:38.644456",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.628461",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# we don't have gene subsets for recount2\n",
+    "# GENE_SELECTION_STRATEGY = \"var_raw\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023325,
+     "end_time": "2021-09-01T16:47:38.678642",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.655317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "CORRELATION_METHOD = pearson\n",
+    "\n",
+    "method_name = CORRELATION_METHOD.__name__\n",
+    "display(method_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017081,
+     "end_time": "2021-09-01T16:47:38.707224",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.690143",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "PERFORMANCE_TEST_N_TOP_GENES = 500"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010528,
+     "end_time": "2021-09-01T16:47:38.728618",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.718090",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017698,
+     "end_time": "2021-09-01T16:47:38.757393",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.739695",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "INPUT_FILE = conf.RECOUNT2[\"DATA_FILE\"]\n",
+    "display(INPUT_FILE)\n",
+    "\n",
+    "assert INPUT_FILE.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019595,
+     "end_time": "2021-09-01T16:47:38.788047",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.768452",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = conf.RECOUNT2[\"SIMILARITY_MATRICES_DIR\"]\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "display(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011293,
+     "end_time": "2021-09-01T16:47:38.811314",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.800021",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Data loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020006,
+     "end_time": "2021-09-01T16:47:38.843018",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.823012",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = pd.read_pickle(INPUT_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013359,
+     "end_time": "2021-09-01T16:47:38.868909",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.855550",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Compute similarity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013364,
+     "end_time": "2021-09-01T16:47:38.895699",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.882335",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Performance test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032647,
+     "end_time": "2021-09-01T16:47:38.942409",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.909762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# select a subset of the genes\n",
+    "test_data = data.sample(n=PERFORMANCE_TEST_N_TOP_GENES, random_state=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019586,
+     "end_time": "2021-09-01T16:47:38.975115",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.955529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.043426,
+     "end_time": "2021-09-01T16:47:39.031725",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.988299",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5903f3f5-791e-4f03-9d79-600102933d04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015078,
+     "end_time": "2021-09-01T16:47:39.061229",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.046151",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027224,
+     "end_time": "2021-09-01T16:47:39.102873",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.075649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
+    "\n",
+    "display(_tmp.shape)\n",
+    "display(_tmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
+   "metadata": {
+    "papermill": {
+     "duration": 4.568251,
+     "end_time": "2021-09-01T16:47:43.686520",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.118269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%timeit CORRELATION_METHOD(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2f7184-c0da-438c-94f5-002912793636",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015392,
+     "end_time": "2021-09-01T16:47:43.716801",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:43.701409",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "189b0295-f968-42b2-9377-a6c404182b01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute correlations\n",
+    "data_corrs = CORRELATION_METHOD(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_filename = OUTPUT_DIR / f\"{INPUT_FILE.stem}-{method_name}.pkl\"\n",
+    "display(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save\n",
+    "data_corrs.to_pickle(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
+   "metadata": {
+    "papermill": {
+     "duration": 0.035801,
+     "end_time": "2021-09-01T16:50:25.296220",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:25.260419",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 168.556635,
+   "end_time": "2021-09-01T16:50:25.542183",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb",
+   "output_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-09-01T16:47:36.985548",
+   "version": "2.3.3"
+  },
+  "toc-autonumbering": true
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
@@ -5,10 +5,10 @@
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
    "metadata": {
     "papermill": {
-     "duration": 0.010569,
-     "end_time": "2021-09-01T16:47:37.867743",
+     "duration": 0.043032,
+     "end_time": "2021-09-09T16:06:28.628958",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.857174",
+     "start_time": "2021-09-09T16:06:28.585926",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
    "metadata": {
     "papermill": {
-     "duration": 0.00983,
-     "end_time": "2021-09-01T16:47:37.887716",
+     "duration": 0.011026,
+     "end_time": "2021-09-09T16:06:28.656363",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.877886",
+     "start_time": "2021-09-09T16:06:28.645337",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.011029,
-     "end_time": "2021-09-01T16:47:37.909510",
+     "duration": 0.010499,
+     "end_time": "2021-09-09T16:06:28.677488",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.898481",
+     "start_time": "2021-09-09T16:06:28.666989",
      "status": "completed"
     },
     "tags": []
@@ -56,14 +56,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:28.704175Z",
+     "iopub.status.busy": "2021-09-09T16:06:28.703608Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.158533Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.158021Z"
+    },
     "papermill": {
-     "duration": 0.676691,
-     "end_time": "2021-09-01T16:47:38.596938",
+     "duration": 0.469643,
+     "end_time": "2021-09-09T16:06:29.158639",
      "exception": false,
-     "start_time": "2021-09-01T16:47:37.920247",
+     "start_time": "2021-09-09T16:06:28.688996",
      "status": "completed"
     },
     "tags": []
@@ -82,10 +88,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.010086,
-     "end_time": "2021-09-01T16:47:38.618172",
+     "duration": 0.010942,
+     "end_time": "2021-09-09T16:06:29.181507",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.608086",
+     "start_time": "2021-09-09T16:06:29.170565",
      "status": "completed"
     },
     "tags": []
@@ -96,14 +102,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.206404Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.205963Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.207751Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.208097Z"
+    },
     "papermill": {
-     "duration": 0.015995,
-     "end_time": "2021-09-01T16:47:38.644456",
+     "duration": 0.015806,
+     "end_time": "2021-09-09T16:06:29.208212",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.628461",
+     "start_time": "2021-09-09T16:06:29.192406",
      "status": "completed"
     },
     "tags": []
@@ -116,19 +128,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.238558Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.237523Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.241769Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.241320Z"
+    },
     "papermill": {
-     "duration": 0.023325,
-     "end_time": "2021-09-01T16:47:38.678642",
+     "duration": 0.022491,
+     "end_time": "2021-09-09T16:06:29.241866",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.655317",
+     "start_time": "2021-09-09T16:06:29.219375",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'spearman'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CORRELATION_METHOD = spearman\n",
     "\n",
@@ -138,14 +166,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.268673Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.268217Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.269669Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.270003Z"
+    },
     "papermill": {
-     "duration": 0.017081,
-     "end_time": "2021-09-01T16:47:38.707224",
+     "duration": 0.016179,
+     "end_time": "2021-09-09T16:06:29.270121",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.690143",
+     "start_time": "2021-09-09T16:06:29.253942",
      "status": "completed"
     },
     "tags": []
@@ -160,10 +194,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.010528,
-     "end_time": "2021-09-01T16:47:38.728618",
+     "duration": 0.011214,
+     "end_time": "2021-09-09T16:06:29.293117",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.718090",
+     "start_time": "2021-09-09T16:06:29.281903",
      "status": "completed"
     },
     "tags": []
@@ -174,19 +208,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.319499Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.318980Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.321749Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.321303Z"
+    },
     "papermill": {
-     "duration": 0.017698,
-     "end_time": "2021-09-01T16:47:38.757393",
+     "duration": 0.017516,
+     "end_time": "2021-09-09T16:06:29.321843",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.739695",
+     "start_time": "2021-09-09T16:06:29.304327",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/data/recount2/recount_data_prep_PLIER.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "INPUT_FILE = conf.RECOUNT2[\"DATA_FILE\"]\n",
     "display(INPUT_FILE)\n",
@@ -196,19 +246,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.349665Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.349012Z",
+     "iopub.status.idle": "2021-09-09T16:06:29.352289Z",
+     "shell.execute_reply": "2021-09-09T16:06:29.351811Z"
+    },
     "papermill": {
-     "duration": 0.019595,
-     "end_time": "2021-09-01T16:47:38.788047",
+     "duration": 0.018663,
+     "end_time": "2021-09-09T16:06:29.352380",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.768452",
+     "start_time": "2021-09-09T16:06:29.333717",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/recount2/similarity_matrices')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "OUTPUT_DIR = conf.RECOUNT2[\"SIMILARITY_MATRICES_DIR\"]\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
@@ -220,10 +286,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.011293,
-     "end_time": "2021-09-01T16:47:38.811314",
+     "duration": 0.01185,
+     "end_time": "2021-09-09T16:06:29.376424",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.800021",
+     "start_time": "2021-09-09T16:06:29.364574",
      "status": "completed"
     },
     "tags": []
@@ -234,14 +300,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:29.403639Z",
+     "iopub.status.busy": "2021-09-09T16:06:29.403189Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.216651Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.216140Z"
+    },
     "papermill": {
-     "duration": 0.020006,
-     "end_time": "2021-09-01T16:47:38.843018",
+     "duration": 0.828425,
+     "end_time": "2021-09-09T16:06:30.216762",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.823012",
+     "start_time": "2021-09-09T16:06:29.388337",
      "status": "completed"
     },
     "tags": []
@@ -253,20 +325,289 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.246768Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.246172Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.248302Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.248671Z"
+    },
+    "papermill": {
+     "duration": 0.018482,
+     "end_time": "2021-09-09T16:06:30.248789",
+     "exception": false,
+     "start_time": "2021-09-09T16:06:30.230307",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 37032)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.282230Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.281731Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.299490Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.299079Z"
+    },
+    "papermill": {
+     "duration": 0.037642,
+     "end_time": "2021-09-09T16:06:30.299586",
+     "exception": false,
+     "start_time": "2021-09-09T16:06:30.261944",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SRP000599.SRR013549</th>\n",
+       "      <th>SRP000599.SRR013550</th>\n",
+       "      <th>SRP000599.SRR013551</th>\n",
+       "      <th>SRP000599.SRR013552</th>\n",
+       "      <th>SRP000599.SRR013553</th>\n",
+       "      <th>SRP000599.SRR013554</th>\n",
+       "      <th>SRP000599.SRR013555</th>\n",
+       "      <th>SRP000599.SRR013556</th>\n",
+       "      <th>SRP000599.SRR013557</th>\n",
+       "      <th>SRP000599.SRR013558</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SRP035599.SRR1139372</th>\n",
+       "      <th>SRP035599.SRR1139393</th>\n",
+       "      <th>SRP035599.SRR1139388</th>\n",
+       "      <th>SRP035599.SRR1139378</th>\n",
+       "      <th>SRP035599.SRR1139399</th>\n",
+       "      <th>SRP035599.SRR1139386</th>\n",
+       "      <th>SRP035599.SRR1139375</th>\n",
+       "      <th>SRP035599.SRR1139382</th>\n",
+       "      <th>SRP035599.SRR1139356</th>\n",
+       "      <th>SRP035599.SRR1139370</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>-0.312500</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.308253</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>-0.312931</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.301711</td>\n",
+       "      <td>-0.305581</td>\n",
+       "      <td>-0.303344</td>\n",
+       "      <td>-0.297800</td>\n",
+       "      <td>-0.307122</td>\n",
+       "      <td>-0.285499</td>\n",
+       "      <td>-0.309599</td>\n",
+       "      <td>-0.300220</td>\n",
+       "      <td>-0.297667</td>\n",
+       "      <td>-0.310151</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.328279</td>\n",
+       "      <td>-0.325140</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.314587</td>\n",
+       "      <td>-0.322952</td>\n",
+       "      <td>-0.326439</td>\n",
+       "      <td>-0.325994</td>\n",
+       "      <td>-0.326272</td>\n",
+       "      <td>-0.322523</td>\n",
+       "      <td>-0.326375</td>\n",
+       "      <td>-0.326339</td>\n",
+       "      <td>-0.322127</td>\n",
+       "      <td>-0.327438</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>-0.286319</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.277195</td>\n",
+       "      <td>-0.256862</td>\n",
+       "      <td>-0.278790</td>\n",
+       "      <td>-0.269701</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286745</td>\n",
+       "      <td>-0.286688</td>\n",
+       "      <td>-0.286725</td>\n",
+       "      <td>-0.286529</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286671</td>\n",
+       "      <td>-0.286859</td>\n",
+       "      <td>-0.286740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>-0.536646</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.807663</td>\n",
+       "      <td>1.294564</td>\n",
+       "      <td>1.527655</td>\n",
+       "      <td>1.404788</td>\n",
+       "      <td>1.047931</td>\n",
+       "      <td>0.892119</td>\n",
+       "      <td>1.507099</td>\n",
+       "      <td>2.458255</td>\n",
+       "      <td>2.919662</td>\n",
+       "      <td>1.410846</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.369171</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>-0.370498</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.345409</td>\n",
+       "      <td>-0.310750</td>\n",
+       "      <td>-0.348120</td>\n",
+       "      <td>-0.356938</td>\n",
+       "      <td>-0.355206</td>\n",
+       "      <td>-0.366197</td>\n",
+       "      <td>-0.351174</td>\n",
+       "      <td>-0.363703</td>\n",
+       "      <td>-0.350825</td>\n",
+       "      <td>-0.360762</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 37032 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          SRP000599.SRR013549  SRP000599.SRR013550  SRP000599.SRR013551  \\\n",
+       "GAS6                -0.312500            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286319            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.369171   \n",
+       "\n",
+       "          SRP000599.SRR013552  SRP000599.SRR013553  SRP000599.SRR013554  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.308253   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.286859            -0.286859            -0.286859   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013555  SRP000599.SRR013556  SRP000599.SRR013557  \\\n",
+       "GAS6                -0.312931            -0.312931            -0.312931   \n",
+       "MMP14               -0.328279            -0.328279            -0.328279   \n",
+       "DSP                 -0.277195            -0.256862            -0.278790   \n",
+       "MARCKSL1            -0.536646            -0.536646            -0.536646   \n",
+       "SPARC               -0.370498            -0.370498            -0.370498   \n",
+       "\n",
+       "          SRP000599.SRR013558  ...  SRP035599.SRR1139372  \\\n",
+       "GAS6                -0.312931  ...             -0.301711   \n",
+       "MMP14               -0.325140  ...             -0.314587   \n",
+       "DSP                 -0.269701  ...             -0.286859   \n",
+       "MARCKSL1            -0.536646  ...              0.807663   \n",
+       "SPARC               -0.370498  ...             -0.345409   \n",
+       "\n",
+       "          SRP035599.SRR1139393  SRP035599.SRR1139388  SRP035599.SRR1139378  \\\n",
+       "GAS6                 -0.305581             -0.303344             -0.297800   \n",
+       "MMP14                -0.322952             -0.326439             -0.325994   \n",
+       "DSP                  -0.286859             -0.286745             -0.286688   \n",
+       "MARCKSL1              1.294564              1.527655              1.404788   \n",
+       "SPARC                -0.310750             -0.348120             -0.356938   \n",
+       "\n",
+       "          SRP035599.SRR1139399  SRP035599.SRR1139386  SRP035599.SRR1139375  \\\n",
+       "GAS6                 -0.307122             -0.285499             -0.309599   \n",
+       "MMP14                -0.326272             -0.322523             -0.326375   \n",
+       "DSP                  -0.286725             -0.286529             -0.286859   \n",
+       "MARCKSL1              1.047931              0.892119              1.507099   \n",
+       "SPARC                -0.355206             -0.366197             -0.351174   \n",
+       "\n",
+       "          SRP035599.SRR1139382  SRP035599.SRR1139356  SRP035599.SRR1139370  \n",
+       "GAS6                 -0.300220             -0.297667             -0.310151  \n",
+       "MMP14                -0.326339             -0.322127             -0.327438  \n",
+       "DSP                  -0.286671             -0.286859             -0.286740  \n",
+       "MARCKSL1              2.458255              2.919662              1.410846  \n",
+       "SPARC                -0.363703             -0.350825             -0.360762  \n",
+       "\n",
+       "[5 rows x 37032 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data.head()"
    ]
@@ -276,10 +617,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.013359,
-     "end_time": "2021-09-01T16:47:38.868909",
+     "duration": 0.012803,
+     "end_time": "2021-09-09T16:06:30.325612",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.855550",
+     "start_time": "2021-09-09T16:06:30.312809",
      "status": "completed"
     },
     "tags": []
@@ -293,10 +634,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.013364,
-     "end_time": "2021-09-01T16:47:38.895699",
+     "duration": 0.012611,
+     "end_time": "2021-09-09T16:06:30.351014",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.882335",
+     "start_time": "2021-09-09T16:06:30.338403",
      "status": "completed"
     },
     "tags": []
@@ -307,14 +648,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.502572Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.501919Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.504432Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.503798Z"
+    },
     "papermill": {
-     "duration": 0.032647,
-     "end_time": "2021-09-01T16:47:38.942409",
+     "duration": 0.140895,
+     "end_time": "2021-09-09T16:06:30.504560",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.909762",
+     "start_time": "2021-09-09T16:06:30.363665",
      "status": "completed"
     },
     "tags": []
@@ -327,38 +674,289 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.543389Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.542834Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.545820Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.545268Z"
+    },
     "papermill": {
-     "duration": 0.019586,
-     "end_time": "2021-09-01T16:47:38.975115",
+     "duration": 0.023535,
+     "end_time": "2021-09-09T16:06:30.545935",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.955529",
+     "start_time": "2021-09-09T16:06:30.522400",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(500, 37032)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.581496Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.581045Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.596774Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.597112Z"
+    },
     "papermill": {
-     "duration": 0.043426,
-     "end_time": "2021-09-01T16:47:39.031725",
+     "duration": 0.035389,
+     "end_time": "2021-09-09T16:06:30.597236",
      "exception": false,
-     "start_time": "2021-09-01T16:47:38.988299",
+     "start_time": "2021-09-09T16:06:30.561847",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SRP000599.SRR013549</th>\n",
+       "      <th>SRP000599.SRR013550</th>\n",
+       "      <th>SRP000599.SRR013551</th>\n",
+       "      <th>SRP000599.SRR013552</th>\n",
+       "      <th>SRP000599.SRR013553</th>\n",
+       "      <th>SRP000599.SRR013554</th>\n",
+       "      <th>SRP000599.SRR013555</th>\n",
+       "      <th>SRP000599.SRR013556</th>\n",
+       "      <th>SRP000599.SRR013557</th>\n",
+       "      <th>SRP000599.SRR013558</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SRP035599.SRR1139372</th>\n",
+       "      <th>SRP035599.SRR1139393</th>\n",
+       "      <th>SRP035599.SRR1139388</th>\n",
+       "      <th>SRP035599.SRR1139378</th>\n",
+       "      <th>SRP035599.SRR1139399</th>\n",
+       "      <th>SRP035599.SRR1139386</th>\n",
+       "      <th>SRP035599.SRR1139375</th>\n",
+       "      <th>SRP035599.SRR1139382</th>\n",
+       "      <th>SRP035599.SRR1139356</th>\n",
+       "      <th>SRP035599.SRR1139370</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>S1PR5</th>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.261464</td>\n",
+       "      <td>-0.262521</td>\n",
+       "      <td>-0.263571</td>\n",
+       "      <td>-0.232207</td>\n",
+       "      <td>-0.263313</td>\n",
+       "      <td>-0.263926</td>\n",
+       "      <td>-0.266852</td>\n",
+       "      <td>-0.266852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>-0.389020</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.264052</td>\n",
+       "      <td>0.141801</td>\n",
+       "      <td>-0.101283</td>\n",
+       "      <td>0.016574</td>\n",
+       "      <td>0.054545</td>\n",
+       "      <td>0.109291</td>\n",
+       "      <td>-0.080455</td>\n",
+       "      <td>-0.039797</td>\n",
+       "      <td>-0.171493</td>\n",
+       "      <td>-0.039619</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EXOSC10</th>\n",
+       "      <td>-0.775256</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>-0.781191</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.151619</td>\n",
+       "      <td>-0.190753</td>\n",
+       "      <td>-0.263083</td>\n",
+       "      <td>0.006409</td>\n",
+       "      <td>-0.090697</td>\n",
+       "      <td>-0.196750</td>\n",
+       "      <td>-0.039938</td>\n",
+       "      <td>0.155149</td>\n",
+       "      <td>0.076707</td>\n",
+       "      <td>0.201055</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ALOX15B</th>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.102583</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.090938</td>\n",
+       "      <td>-0.104175</td>\n",
+       "      <td>-0.091455</td>\n",
+       "      <td>-0.097841</td>\n",
+       "      <td>-0.097053</td>\n",
+       "      <td>-0.098525</td>\n",
+       "      <td>-0.102490</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CACNB1</th>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>-0.412386</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.002829</td>\n",
+       "      <td>-0.176210</td>\n",
+       "      <td>-0.124728</td>\n",
+       "      <td>-0.034000</td>\n",
+       "      <td>-0.170579</td>\n",
+       "      <td>-0.134903</td>\n",
+       "      <td>-0.050322</td>\n",
+       "      <td>-0.160912</td>\n",
+       "      <td>-0.034017</td>\n",
+       "      <td>-0.001866</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 37032 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         SRP000599.SRR013549  SRP000599.SRR013550  SRP000599.SRR013551  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.775256            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013552  SRP000599.SRR013553  SRP000599.SRR013554  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.781191            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013555  SRP000599.SRR013556  SRP000599.SRR013557  \\\n",
+       "S1PR5              -0.266852            -0.266852            -0.266852   \n",
+       "NDUFA12            -0.389020            -0.389020            -0.389020   \n",
+       "EXOSC10            -0.781191            -0.781191            -0.781191   \n",
+       "ALOX15B            -0.104175            -0.104175            -0.104175   \n",
+       "CACNB1             -0.412386            -0.412386            -0.412386   \n",
+       "\n",
+       "         SRP000599.SRR013558  ...  SRP035599.SRR1139372  SRP035599.SRR1139393  \\\n",
+       "S1PR5              -0.266852  ...             -0.266852             -0.266852   \n",
+       "NDUFA12            -0.389020  ...              0.264052              0.141801   \n",
+       "EXOSC10            -0.781191  ...             -0.151619             -0.190753   \n",
+       "ALOX15B            -0.104175  ...             -0.102583             -0.104175   \n",
+       "CACNB1             -0.412386  ...             -0.002829             -0.176210   \n",
+       "\n",
+       "         SRP035599.SRR1139388  SRP035599.SRR1139378  SRP035599.SRR1139399  \\\n",
+       "S1PR5               -0.261464             -0.262521             -0.263571   \n",
+       "NDUFA12             -0.101283              0.016574              0.054545   \n",
+       "EXOSC10             -0.263083              0.006409             -0.090697   \n",
+       "ALOX15B             -0.104175             -0.090938             -0.104175   \n",
+       "CACNB1              -0.124728             -0.034000             -0.170579   \n",
+       "\n",
+       "         SRP035599.SRR1139386  SRP035599.SRR1139375  SRP035599.SRR1139382  \\\n",
+       "S1PR5               -0.232207             -0.263313             -0.263926   \n",
+       "NDUFA12              0.109291             -0.080455             -0.039797   \n",
+       "EXOSC10             -0.196750             -0.039938              0.155149   \n",
+       "ALOX15B             -0.091455             -0.097841             -0.097053   \n",
+       "CACNB1              -0.134903             -0.050322             -0.160912   \n",
+       "\n",
+       "         SRP035599.SRR1139356  SRP035599.SRR1139370  \n",
+       "S1PR5               -0.266852             -0.266852  \n",
+       "NDUFA12             -0.171493             -0.039619  \n",
+       "EXOSC10              0.076707              0.201055  \n",
+       "ALOX15B             -0.098525             -0.102490  \n",
+       "CACNB1              -0.034017             -0.001866  \n",
+       "\n",
+       "[5 rows x 37032 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_data.head()"
    ]
@@ -368,10 +966,10 @@
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
    "metadata": {
     "papermill": {
-     "duration": 0.015078,
-     "end_time": "2021-09-01T16:47:39.061229",
+     "duration": 0.014157,
+     "end_time": "2021-09-09T16:06:30.625855",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.046151",
+     "start_time": "2021-09-09T16:06:30.611698",
      "status": "completed"
     },
     "tags": []
@@ -382,19 +980,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.656863Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.656271Z",
+     "iopub.status.idle": "2021-09-09T16:06:30.674309Z",
+     "shell.execute_reply": "2021-09-09T16:06:30.673847Z"
+    },
     "papermill": {
-     "duration": 0.027224,
-     "end_time": "2021-09-01T16:47:39.102873",
+     "duration": 0.034636,
+     "end_time": "2021-09-09T16:06:30.674406",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.075649",
+     "start_time": "2021-09-09T16:06:30.639770",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 3)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>S1PR5</th>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <th>EXOSC10</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>S1PR5</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.08518</td>\n",
+       "      <td>0.273537</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NDUFA12</th>\n",
+       "      <td>0.085180</td>\n",
+       "      <td>1.00000</td>\n",
+       "      <td>0.416500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EXOSC10</th>\n",
+       "      <td>0.273537</td>\n",
+       "      <td>0.41650</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            S1PR5  NDUFA12   EXOSC10\n",
+       "S1PR5    1.000000  0.08518  0.273537\n",
+       "NDUFA12  0.085180  1.00000  0.416500\n",
+       "EXOSC10  0.273537  0.41650  1.000000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
     "\n",
@@ -404,19 +1077,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:06:30.716898Z",
+     "iopub.status.busy": "2021-09-09T16:06:30.716202Z",
+     "iopub.status.idle": "2021-09-09T16:07:11.014328Z",
+     "shell.execute_reply": "2021-09-09T16:07:11.014690Z"
+    },
     "papermill": {
-     "duration": 4.568251,
-     "end_time": "2021-09-01T16:47:43.686520",
+     "duration": 40.325588,
+     "end_time": "2021-09-09T16:07:11.014807",
      "exception": false,
-     "start_time": "2021-09-01T16:47:39.118269",
+     "start_time": "2021-09-09T16:06:30.689219",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.03 s ± 1.79 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit CORRELATION_METHOD(test_data)"
    ]
@@ -426,10 +1113,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.015392,
-     "end_time": "2021-09-01T16:47:43.716801",
+     "duration": 0.014595,
+     "end_time": "2021-09-09T16:07:11.044637",
      "exception": false,
-     "start_time": "2021-09-01T16:47:43.701409",
+     "start_time": "2021-09-09T16:07:11.030042",
      "status": "completed"
     },
     "tags": []
@@ -440,9 +1127,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "189b0295-f968-42b2-9377-a6c404182b01",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:07:11.076776Z",
+     "iopub.status.busy": "2021-09-09T16:07:11.076324Z",
+     "iopub.status.idle": "2021-09-09T16:18:10.332647Z",
+     "shell.execute_reply": "2021-09-09T16:18:10.332089Z"
+    },
+    "papermill": {
+     "duration": 659.273633,
+     "end_time": "2021-09-09T16:18:10.332787",
+     "exception": false,
+     "start_time": "2021-09-09T16:07:11.059154",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# compute correlations\n",
@@ -451,10 +1153,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:18:10.372393Z",
+     "iopub.status.busy": "2021-09-09T16:18:10.371925Z",
+     "iopub.status.idle": "2021-09-09T16:18:10.373986Z",
+     "shell.execute_reply": "2021-09-09T16:18:10.374338Z"
+    },
+    "papermill": {
+     "duration": 0.022338,
+     "end_time": "2021-09-09T16:18:10.374461",
+     "exception": false,
+     "start_time": "2021-09-09T16:18:10.352123",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/opt/data/results/recount2/similarity_matrices/recount_data_prep_PLIER-spearman.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "output_filename = OUTPUT_DIR / f\"{INPUT_FILE.stem}-{method_name}.pkl\"\n",
     "display(output_filename)"
@@ -462,9 +1189,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T16:18:10.410176Z",
+     "iopub.status.busy": "2021-09-09T16:18:10.409711Z",
+     "iopub.status.idle": "2021-09-09T16:18:10.607711Z",
+     "shell.execute_reply": "2021-09-09T16:18:10.607253Z"
+    },
+    "papermill": {
+     "duration": 0.217088,
+     "end_time": "2021-09-09T16:18:10.607819",
+     "exception": false,
+     "start_time": "2021-09-09T16:18:10.390731",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# save\n",
@@ -477,10 +1219,10 @@
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
    "metadata": {
     "papermill": {
-     "duration": 0.035801,
-     "end_time": "2021-09-01T16:50:25.296220",
+     "duration": 0.01582,
+     "end_time": "2021-09-09T16:18:10.640608",
      "exception": false,
-     "start_time": "2021-09-01T16:50:25.260419",
+     "start_time": "2021-09-09T16:18:10.624788",
      "status": "completed"
     },
     "tags": []
@@ -491,13 +1233,7 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -514,18 +1250,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 168.556635,
-   "end_time": "2021-09-01T16:50:25.542183",
+   "duration": 703.445278,
+   "end_time": "2021-09-09T16:18:10.963712",
    "environment_variables": {},
    "exception": null,
-   "input_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb",
-   "output_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.run.ipynb",
+   "input_path": "nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb",
+   "output_path": "nbs/10_compute_correlations/10_recount2/06-recount2-spearman.run.ipynb",
    "parameters": {},
-   "start_time": "2021-09-01T16:47:36.985548",
+   "start_time": "2021-09-09T16:06:27.518434",
    "version": "2.3.3"
   },
   "toc-autonumbering": true

--- a/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
@@ -1,0 +1,535 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010569,
+     "end_time": "2021-09-01T16:47:37.867743",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.857174",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00983,
+     "end_time": "2021-09-01T16:47:37.887716",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.877886",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "According to the settings specified below, this notebook:\n",
+    " 1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),\n",
+    " 2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and\n",
+    " 3. computes the correlation matrix across all the genes using the correlation coefficient specified."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011029,
+     "end_time": "2021-09-01T16:47:37.909510",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.898481",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.676691,
+     "end_time": "2021-09-01T16:47:38.596938",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:37.920247",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from clustermatch import conf\n",
+    "from clustermatch.corr import spearman"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010086,
+     "end_time": "2021-09-01T16:47:38.618172",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.608086",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56ff94d3-a230-4028-a71d-518ac109209b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015995,
+     "end_time": "2021-09-01T16:47:38.644456",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.628461",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# we don't have gene subsets for recount2\n",
+    "# GENE_SELECTION_STRATEGY = \"var_raw\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023325,
+     "end_time": "2021-09-01T16:47:38.678642",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.655317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "CORRELATION_METHOD = spearman\n",
+    "\n",
+    "method_name = CORRELATION_METHOD.__name__\n",
+    "display(method_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017081,
+     "end_time": "2021-09-01T16:47:38.707224",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.690143",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "PERFORMANCE_TEST_N_TOP_GENES = 500"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010528,
+     "end_time": "2021-09-01T16:47:38.728618",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.718090",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017698,
+     "end_time": "2021-09-01T16:47:38.757393",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.739695",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "INPUT_FILE = conf.RECOUNT2[\"DATA_FILE\"]\n",
+    "display(INPUT_FILE)\n",
+    "\n",
+    "assert INPUT_FILE.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019595,
+     "end_time": "2021-09-01T16:47:38.788047",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.768452",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = conf.RECOUNT2[\"SIMILARITY_MATRICES_DIR\"]\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "display(OUTPUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011293,
+     "end_time": "2021-09-01T16:47:38.811314",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.800021",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Data loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020006,
+     "end_time": "2021-09-01T16:47:38.843018",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.823012",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = pd.read_pickle(INPUT_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013359,
+     "end_time": "2021-09-01T16:47:38.868909",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.855550",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Compute similarity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013364,
+     "end_time": "2021-09-01T16:47:38.895699",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.882335",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Performance test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032647,
+     "end_time": "2021-09-01T16:47:38.942409",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.909762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# select a subset of the genes\n",
+    "test_data = data.sample(n=PERFORMANCE_TEST_N_TOP_GENES, random_state=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019586,
+     "end_time": "2021-09-01T16:47:38.975115",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.955529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.043426,
+     "end_time": "2021-09-01T16:47:39.031725",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:38.988299",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5903f3f5-791e-4f03-9d79-600102933d04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015078,
+     "end_time": "2021-09-01T16:47:39.061229",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.046151",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027224,
+     "end_time": "2021-09-01T16:47:39.102873",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.075649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "_tmp = CORRELATION_METHOD(test_data.iloc[:3])\n",
+    "\n",
+    "display(_tmp.shape)\n",
+    "display(_tmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
+   "metadata": {
+    "papermill": {
+     "duration": 4.568251,
+     "end_time": "2021-09-01T16:47:43.686520",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:39.118269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%timeit CORRELATION_METHOD(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2f7184-c0da-438c-94f5-002912793636",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015392,
+     "end_time": "2021-09-01T16:47:43.716801",
+     "exception": false,
+     "start_time": "2021-09-01T16:47:43.701409",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "189b0295-f968-42b2-9377-a6c404182b01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute correlations\n",
+    "data_corrs = CORRELATION_METHOD(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_filename = OUTPUT_DIR / f\"{INPUT_FILE.stem}-{method_name}.pkl\"\n",
+    "display(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save\n",
+    "data_corrs.to_pickle(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
+   "metadata": {
+    "papermill": {
+     "duration": 0.035801,
+     "end_time": "2021-09-01T16:50:25.296220",
+     "exception": false,
+     "start_time": "2021-09-01T16:50:25.260419",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent",
+    "format_version": "1.3",
+    "jupytext_version": "1.11.5"
+   }
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 168.556635,
+   "end_time": "2021-09-01T16:50:25.542183",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.ipynb",
+   "output_path": "nbs/10_compute_correlations/05_gtex_v8/05-gtex-pearson.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-09-01T16:47:36.985548",
+   "version": "2.3.3"
+  },
+  "toc-autonumbering": true
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
@@ -5,10 +5,10 @@
    "id": "e9773a95-e8fd-4963-87a5-0c92299434d5",
    "metadata": {
     "papermill": {
-     "duration": 0.043032,
-     "end_time": "2021-09-09T16:06:28.628958",
+     "duration": 0.016785,
+     "end_time": "2021-09-09T17:30:46.030526",
      "exception": false,
-     "start_time": "2021-09-09T16:06:28.585926",
+     "start_time": "2021-09-09T17:30:46.013741",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "57f34c74-404d-4776-b547-e6acb2df75d7",
    "metadata": {
     "papermill": {
-     "duration": 0.011026,
-     "end_time": "2021-09-09T16:06:28.656363",
+     "duration": 0.012487,
+     "end_time": "2021-09-09T17:30:46.055748",
      "exception": false,
-     "start_time": "2021-09-09T16:06:28.645337",
+     "start_time": "2021-09-09T17:30:46.043261",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "1d8fae6b-e623-46a6-aff6-d7849163c820",
    "metadata": {
     "papermill": {
-     "duration": 0.010499,
-     "end_time": "2021-09-09T16:06:28.677488",
+     "duration": 0.01253,
+     "end_time": "2021-09-09T17:30:46.081984",
      "exception": false,
-     "start_time": "2021-09-09T16:06:28.666989",
+     "start_time": "2021-09-09T17:30:46.069454",
      "status": "completed"
     },
     "tags": []
@@ -60,16 +60,16 @@
    "id": "76729f0e-f742-495b-b676-d9d7b1539e10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:28.704175Z",
-     "iopub.status.busy": "2021-09-09T16:06:28.703608Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.158533Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.158021Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.114597Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.114157Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.581992Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.581467Z"
     },
     "papermill": {
-     "duration": 0.469643,
-     "end_time": "2021-09-09T16:06:29.158639",
+     "duration": 0.487518,
+     "end_time": "2021-09-09T17:30:46.582102",
      "exception": false,
-     "start_time": "2021-09-09T16:06:28.688996",
+     "start_time": "2021-09-09T17:30:46.094584",
      "status": "completed"
     },
     "tags": []
@@ -87,10 +87,10 @@
    "id": "a6c3a546-9a49-45e7-9f17-fbdb5af4bfb6",
    "metadata": {
     "papermill": {
-     "duration": 0.010942,
-     "end_time": "2021-09-09T16:06:29.181507",
+     "duration": 0.01289,
+     "end_time": "2021-09-09T17:30:46.608003",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.170565",
+     "start_time": "2021-09-09T17:30:46.595113",
      "status": "completed"
     },
     "tags": []
@@ -105,16 +105,16 @@
    "id": "56ff94d3-a230-4028-a71d-518ac109209b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.206404Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.205963Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.207751Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.208097Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.637007Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.636570Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.638403Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.638777Z"
     },
     "papermill": {
-     "duration": 0.015806,
-     "end_time": "2021-09-09T16:06:29.208212",
+     "duration": 0.017773,
+     "end_time": "2021-09-09T17:30:46.638887",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.192406",
+     "start_time": "2021-09-09T17:30:46.621114",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "8baf4209-ba56-4e3d-b60f-6ce2bb686159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.238558Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.237523Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.241769Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.241320Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.672923Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.672369Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.676158Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.676550Z"
     },
     "papermill": {
-     "duration": 0.022491,
-     "end_time": "2021-09-09T16:06:29.241866",
+     "duration": 0.024148,
+     "end_time": "2021-09-09T17:30:46.676668",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.219375",
+     "start_time": "2021-09-09T17:30:46.652520",
      "status": "completed"
     },
     "tags": []
@@ -169,16 +169,16 @@
    "id": "21a3e349-9a09-4d24-89e3-915fdbf08a81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.268673Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.268217Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.269669Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.270003Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.706557Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.706117Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.708243Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.707832Z"
     },
     "papermill": {
-     "duration": 0.016179,
-     "end_time": "2021-09-09T16:06:29.270121",
+     "duration": 0.018167,
+     "end_time": "2021-09-09T17:30:46.708336",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.253942",
+     "start_time": "2021-09-09T17:30:46.690169",
      "status": "completed"
     },
     "tags": []
@@ -193,10 +193,10 @@
    "id": "b0afcba9-5847-414e-b448-f0cd08ecd8ce",
    "metadata": {
     "papermill": {
-     "duration": 0.011214,
-     "end_time": "2021-09-09T16:06:29.293117",
+     "duration": 0.012997,
+     "end_time": "2021-09-09T17:30:46.734806",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.281903",
+     "start_time": "2021-09-09T17:30:46.721809",
      "status": "completed"
     },
     "tags": []
@@ -211,16 +211,16 @@
    "id": "35760114-8560-4a0e-ad4f-2bee9104c63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.319499Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.318980Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.321749Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.321303Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.764627Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.764162Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.766973Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.766592Z"
     },
     "papermill": {
-     "duration": 0.017516,
-     "end_time": "2021-09-09T16:06:29.321843",
+     "duration": 0.019159,
+     "end_time": "2021-09-09T17:30:46.767067",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.304327",
+     "start_time": "2021-09-09T17:30:46.747908",
      "status": "completed"
     },
     "tags": []
@@ -249,16 +249,16 @@
    "id": "f1418e81-4e77-4f67-b5ed-b29b797e31a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.349665Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.349012Z",
-     "iopub.status.idle": "2021-09-09T16:06:29.352289Z",
-     "shell.execute_reply": "2021-09-09T16:06:29.351811Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.798727Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.798107Z",
+     "iopub.status.idle": "2021-09-09T17:30:46.801085Z",
+     "shell.execute_reply": "2021-09-09T17:30:46.800624Z"
     },
     "papermill": {
-     "duration": 0.018663,
-     "end_time": "2021-09-09T16:06:29.352380",
+     "duration": 0.020225,
+     "end_time": "2021-09-09T17:30:46.801182",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.333717",
+     "start_time": "2021-09-09T17:30:46.780957",
      "status": "completed"
     },
     "tags": []
@@ -285,10 +285,10 @@
    "id": "5fdf8df6-eba0-4cf5-979c-3acd56a5ef3c",
    "metadata": {
     "papermill": {
-     "duration": 0.01185,
-     "end_time": "2021-09-09T16:06:29.376424",
+     "duration": 0.01448,
+     "end_time": "2021-09-09T17:30:46.830425",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.364574",
+     "start_time": "2021-09-09T17:30:46.815945",
      "status": "completed"
     },
     "tags": []
@@ -303,16 +303,16 @@
    "id": "596d25ed-4120-4bef-8984-a91ae6529ab5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:29.403639Z",
-     "iopub.status.busy": "2021-09-09T16:06:29.403189Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.216651Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.216140Z"
+     "iopub.execute_input": "2021-09-09T17:30:46.861353Z",
+     "iopub.status.busy": "2021-09-09T17:30:46.860867Z",
+     "iopub.status.idle": "2021-09-09T17:30:47.723797Z",
+     "shell.execute_reply": "2021-09-09T17:30:47.723276Z"
     },
     "papermill": {
-     "duration": 0.828425,
-     "end_time": "2021-09-09T16:06:30.216762",
+     "duration": 0.879585,
+     "end_time": "2021-09-09T17:30:47.723919",
      "exception": false,
-     "start_time": "2021-09-09T16:06:29.388337",
+     "start_time": "2021-09-09T17:30:46.844334",
      "status": "completed"
     },
     "tags": []
@@ -328,16 +328,16 @@
    "id": "be8a23da-ea99-43a9-b684-fa645c1d1adc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.246768Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.246172Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.248302Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.248671Z"
+     "iopub.execute_input": "2021-09-09T17:30:47.758472Z",
+     "iopub.status.busy": "2021-09-09T17:30:47.757894Z",
+     "iopub.status.idle": "2021-09-09T17:30:47.760702Z",
+     "shell.execute_reply": "2021-09-09T17:30:47.760325Z"
     },
     "papermill": {
-     "duration": 0.018482,
-     "end_time": "2021-09-09T16:06:30.248789",
+     "duration": 0.021083,
+     "end_time": "2021-09-09T17:30:47.760797",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.230307",
+     "start_time": "2021-09-09T17:30:47.739714",
      "status": "completed"
     },
     "tags": []
@@ -364,16 +364,16 @@
    "id": "cd693523-4379-400a-a2d2-6b3f617421e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.282230Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.281731Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.299490Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.299079Z"
+     "iopub.execute_input": "2021-09-09T17:30:47.796795Z",
+     "iopub.status.busy": "2021-09-09T17:30:47.796328Z",
+     "iopub.status.idle": "2021-09-09T17:30:47.813072Z",
+     "shell.execute_reply": "2021-09-09T17:30:47.813416Z"
     },
     "papermill": {
-     "duration": 0.037642,
-     "end_time": "2021-09-09T16:06:30.299586",
+     "duration": 0.038562,
+     "end_time": "2021-09-09T17:30:47.813538",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.261944",
+     "start_time": "2021-09-09T17:30:47.774976",
      "status": "completed"
     },
     "tags": []
@@ -616,10 +616,10 @@
    "id": "081da632-fd12-462a-9ae1-c0ceccf1bb5d",
    "metadata": {
     "papermill": {
-     "duration": 0.012803,
-     "end_time": "2021-09-09T16:06:30.325612",
+     "duration": 0.014482,
+     "end_time": "2021-09-09T17:30:47.842884",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.312809",
+     "start_time": "2021-09-09T17:30:47.828402",
      "status": "completed"
     },
     "tags": []
@@ -633,10 +633,10 @@
    "id": "37137fff-2d3a-43d8-9bd5-d7c3284a97f5",
    "metadata": {
     "papermill": {
-     "duration": 0.012611,
-     "end_time": "2021-09-09T16:06:30.351014",
+     "duration": 0.01457,
+     "end_time": "2021-09-09T17:30:47.871682",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.338403",
+     "start_time": "2021-09-09T17:30:47.857112",
      "status": "completed"
     },
     "tags": []
@@ -651,16 +651,16 @@
    "id": "5dd40707-759f-4bf9-b8cc-84811b2dfe53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.502572Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.501919Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.504432Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.503798Z"
+     "iopub.execute_input": "2021-09-09T17:30:48.050053Z",
+     "iopub.status.busy": "2021-09-09T17:30:48.049325Z",
+     "iopub.status.idle": "2021-09-09T17:30:48.051728Z",
+     "shell.execute_reply": "2021-09-09T17:30:48.051199Z"
     },
     "papermill": {
-     "duration": 0.140895,
-     "end_time": "2021-09-09T16:06:30.504560",
+     "duration": 0.166034,
+     "end_time": "2021-09-09T17:30:48.051883",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.363665",
+     "start_time": "2021-09-09T17:30:47.885849",
      "status": "completed"
     },
     "tags": []
@@ -677,16 +677,16 @@
    "id": "e8acd036-93f7-46c0-a1ee-8da0c2c24790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.543389Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.542834Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.545820Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.545268Z"
+     "iopub.execute_input": "2021-09-09T17:30:48.094203Z",
+     "iopub.status.busy": "2021-09-09T17:30:48.093637Z",
+     "iopub.status.idle": "2021-09-09T17:30:48.096710Z",
+     "shell.execute_reply": "2021-09-09T17:30:48.096148Z"
     },
     "papermill": {
-     "duration": 0.023535,
-     "end_time": "2021-09-09T16:06:30.545935",
+     "duration": 0.025275,
+     "end_time": "2021-09-09T17:30:48.096830",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.522400",
+     "start_time": "2021-09-09T17:30:48.071555",
      "status": "completed"
     },
     "tags": []
@@ -713,16 +713,16 @@
    "id": "111e360b-dbe4-4b69-9029-7b7669eb5ddc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.581496Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.581045Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.596774Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.597112Z"
+     "iopub.execute_input": "2021-09-09T17:30:48.136473Z",
+     "iopub.status.busy": "2021-09-09T17:30:48.136009Z",
+     "iopub.status.idle": "2021-09-09T17:30:48.152552Z",
+     "shell.execute_reply": "2021-09-09T17:30:48.152096Z"
     },
     "papermill": {
-     "duration": 0.035389,
-     "end_time": "2021-09-09T16:06:30.597236",
+     "duration": 0.037495,
+     "end_time": "2021-09-09T17:30:48.152651",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.561847",
+     "start_time": "2021-09-09T17:30:48.115156",
      "status": "completed"
     },
     "tags": []
@@ -965,10 +965,10 @@
    "id": "5903f3f5-791e-4f03-9d79-600102933d04",
    "metadata": {
     "papermill": {
-     "duration": 0.014157,
-     "end_time": "2021-09-09T16:06:30.625855",
+     "duration": 0.01486,
+     "end_time": "2021-09-09T17:30:48.183197",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.611698",
+     "start_time": "2021-09-09T17:30:48.168337",
      "status": "completed"
     },
     "tags": []
@@ -983,16 +983,16 @@
    "id": "118a6631-1cfd-44a3-bd85-5ec7118edd03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.656863Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.656271Z",
-     "iopub.status.idle": "2021-09-09T16:06:30.674309Z",
-     "shell.execute_reply": "2021-09-09T16:06:30.673847Z"
+     "iopub.execute_input": "2021-09-09T17:30:48.216728Z",
+     "iopub.status.busy": "2021-09-09T17:30:48.216228Z",
+     "iopub.status.idle": "2021-09-09T17:30:48.234093Z",
+     "shell.execute_reply": "2021-09-09T17:30:48.233629Z"
     },
     "papermill": {
-     "duration": 0.034636,
-     "end_time": "2021-09-09T16:06:30.674406",
+     "duration": 0.036028,
+     "end_time": "2021-09-09T17:30:48.234190",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.639770",
+     "start_time": "2021-09-09T17:30:48.198162",
      "status": "completed"
     },
     "tags": []
@@ -1080,16 +1080,16 @@
    "id": "d32281d8-f640-4f87-a1d5-aefa0757e9c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:06:30.716898Z",
-     "iopub.status.busy": "2021-09-09T16:06:30.716202Z",
-     "iopub.status.idle": "2021-09-09T16:07:11.014328Z",
-     "shell.execute_reply": "2021-09-09T16:07:11.014690Z"
+     "iopub.execute_input": "2021-09-09T17:30:48.270557Z",
+     "iopub.status.busy": "2021-09-09T17:30:48.270021Z",
+     "iopub.status.idle": "2021-09-09T17:31:28.351863Z",
+     "shell.execute_reply": "2021-09-09T17:31:28.352255Z"
     },
     "papermill": {
-     "duration": 40.325588,
-     "end_time": "2021-09-09T16:07:11.014807",
+     "duration": 40.101607,
+     "end_time": "2021-09-09T17:31:28.352369",
      "exception": false,
-     "start_time": "2021-09-09T16:06:30.689219",
+     "start_time": "2021-09-09T17:30:48.250762",
      "status": "completed"
     },
     "tags": []
@@ -1099,7 +1099,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.03 s ± 1.79 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "5 s ± 4.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1112,10 +1112,10 @@
    "id": "fc2f7184-c0da-438c-94f5-002912793636",
    "metadata": {
     "papermill": {
-     "duration": 0.014595,
-     "end_time": "2021-09-09T16:07:11.044637",
+     "duration": 0.015438,
+     "end_time": "2021-09-09T17:31:28.383887",
      "exception": false,
-     "start_time": "2021-09-09T16:07:11.030042",
+     "start_time": "2021-09-09T17:31:28.368449",
      "status": "completed"
     },
     "tags": []
@@ -1130,16 +1130,16 @@
    "id": "189b0295-f968-42b2-9377-a6c404182b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:07:11.076776Z",
-     "iopub.status.busy": "2021-09-09T16:07:11.076324Z",
-     "iopub.status.idle": "2021-09-09T16:18:10.332647Z",
-     "shell.execute_reply": "2021-09-09T16:18:10.332089Z"
+     "iopub.execute_input": "2021-09-09T17:31:28.418110Z",
+     "iopub.status.busy": "2021-09-09T17:31:28.417657Z",
+     "iopub.status.idle": "2021-09-09T17:42:52.494662Z",
+     "shell.execute_reply": "2021-09-09T17:42:52.494053Z"
     },
     "papermill": {
-     "duration": 659.273633,
-     "end_time": "2021-09-09T16:18:10.332787",
+     "duration": 684.095289,
+     "end_time": "2021-09-09T17:42:52.494800",
      "exception": false,
-     "start_time": "2021-09-09T16:07:11.059154",
+     "start_time": "2021-09-09T17:31:28.399511",
      "status": "completed"
     },
     "tags": []
@@ -1152,10 +1152,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "bd93f2d7-d1fe-46c5-9a8c-92cac91ef7c6",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T17:42:53.430498Z",
+     "iopub.status.busy": "2021-09-09T17:42:53.428614Z",
+     "iopub.status.idle": "2021-09-09T17:42:53.436466Z",
+     "shell.execute_reply": "2021-09-09T17:42:53.437911Z"
+    },
+    "papermill": {
+     "duration": 0.922874,
+     "end_time": "2021-09-09T17:42:53.438364",
+     "exception": false,
+     "start_time": "2021-09-09T17:42:52.515490",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6750, 6750)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(data_corrs.shape)\n",
     "\n",
@@ -1164,30 +1189,252 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "da4f952a-539d-4007-bbfb-a57e426fb68a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-09-09T17:42:53.509353Z",
+     "iopub.status.busy": "2021-09-09T17:42:53.508880Z",
+     "iopub.status.idle": "2021-09-09T17:42:53.524586Z",
+     "shell.execute_reply": "2021-09-09T17:42:53.524136Z"
+    },
+    "papermill": {
+     "duration": 0.038412,
+     "end_time": "2021-09-09T17:42:53.524685",
+     "exception": false,
+     "start_time": "2021-09-09T17:42:53.486273",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GAS6</th>\n",
+       "      <th>MMP14</th>\n",
+       "      <th>DSP</th>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <th>SPARC</th>\n",
+       "      <th>CTSD</th>\n",
+       "      <th>EPAS1</th>\n",
+       "      <th>PALLD</th>\n",
+       "      <th>PHC2</th>\n",
+       "      <th>LGALS3BP</th>\n",
+       "      <th>...</th>\n",
+       "      <th>LDHB</th>\n",
+       "      <th>LDHC</th>\n",
+       "      <th>ACAP2</th>\n",
+       "      <th>ACAP3</th>\n",
+       "      <th>CFL2</th>\n",
+       "      <th>CFL1</th>\n",
+       "      <th>NFIB</th>\n",
+       "      <th>PLEKHG6</th>\n",
+       "      <th>GNGT2</th>\n",
+       "      <th>SERPINH1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>GAS6</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.767277</td>\n",
+       "      <td>0.530435</td>\n",
+       "      <td>0.376058</td>\n",
+       "      <td>0.492968</td>\n",
+       "      <td>0.652806</td>\n",
+       "      <td>0.694218</td>\n",
+       "      <td>0.598491</td>\n",
+       "      <td>0.599584</td>\n",
+       "      <td>0.595290</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.096758</td>\n",
+       "      <td>0.319135</td>\n",
+       "      <td>0.243757</td>\n",
+       "      <td>0.669781</td>\n",
+       "      <td>0.433053</td>\n",
+       "      <td>0.397045</td>\n",
+       "      <td>0.298712</td>\n",
+       "      <td>0.484416</td>\n",
+       "      <td>0.357766</td>\n",
+       "      <td>0.689587</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP14</th>\n",
+       "      <td>0.767277</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.490369</td>\n",
+       "      <td>0.372943</td>\n",
+       "      <td>0.593585</td>\n",
+       "      <td>0.608753</td>\n",
+       "      <td>0.652577</td>\n",
+       "      <td>0.566899</td>\n",
+       "      <td>0.596954</td>\n",
+       "      <td>0.591671</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.108111</td>\n",
+       "      <td>0.328656</td>\n",
+       "      <td>0.295322</td>\n",
+       "      <td>0.573781</td>\n",
+       "      <td>0.372953</td>\n",
+       "      <td>0.388056</td>\n",
+       "      <td>0.232660</td>\n",
+       "      <td>0.498833</td>\n",
+       "      <td>0.371384</td>\n",
+       "      <td>0.707476</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DSP</th>\n",
+       "      <td>0.530435</td>\n",
+       "      <td>0.490369</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.309156</td>\n",
+       "      <td>0.250510</td>\n",
+       "      <td>0.378827</td>\n",
+       "      <td>0.570500</td>\n",
+       "      <td>0.603818</td>\n",
+       "      <td>0.261268</td>\n",
+       "      <td>0.483510</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.102505</td>\n",
+       "      <td>0.322113</td>\n",
+       "      <td>0.181120</td>\n",
+       "      <td>0.336312</td>\n",
+       "      <td>0.389993</td>\n",
+       "      <td>0.143608</td>\n",
+       "      <td>0.396473</td>\n",
+       "      <td>0.567024</td>\n",
+       "      <td>0.022467</td>\n",
+       "      <td>0.615777</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MARCKSL1</th>\n",
+       "      <td>0.376058</td>\n",
+       "      <td>0.372943</td>\n",
+       "      <td>0.309156</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.251116</td>\n",
+       "      <td>0.380241</td>\n",
+       "      <td>0.254586</td>\n",
+       "      <td>0.286491</td>\n",
+       "      <td>0.441862</td>\n",
+       "      <td>0.339611</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.386577</td>\n",
+       "      <td>0.314713</td>\n",
+       "      <td>0.302932</td>\n",
+       "      <td>0.548047</td>\n",
+       "      <td>0.313833</td>\n",
+       "      <td>0.454887</td>\n",
+       "      <td>0.228858</td>\n",
+       "      <td>0.352535</td>\n",
+       "      <td>0.312589</td>\n",
+       "      <td>0.478413</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPARC</th>\n",
+       "      <td>0.492968</td>\n",
+       "      <td>0.593585</td>\n",
+       "      <td>0.250510</td>\n",
+       "      <td>0.251116</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.299277</td>\n",
+       "      <td>0.404538</td>\n",
+       "      <td>0.481395</td>\n",
+       "      <td>0.353212</td>\n",
+       "      <td>0.426300</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.259254</td>\n",
+       "      <td>0.219185</td>\n",
+       "      <td>0.128572</td>\n",
+       "      <td>0.276951</td>\n",
+       "      <td>0.441842</td>\n",
+       "      <td>0.182518</td>\n",
+       "      <td>0.339385</td>\n",
+       "      <td>0.180845</td>\n",
+       "      <td>0.240672</td>\n",
+       "      <td>0.503508</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 6750 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              GAS6     MMP14       DSP  MARCKSL1     SPARC      CTSD  \\\n",
+       "GAS6      1.000000  0.767277  0.530435  0.376058  0.492968  0.652806   \n",
+       "MMP14     0.767277  1.000000  0.490369  0.372943  0.593585  0.608753   \n",
+       "DSP       0.530435  0.490369  1.000000  0.309156  0.250510  0.378827   \n",
+       "MARCKSL1  0.376058  0.372943  0.309156  1.000000  0.251116  0.380241   \n",
+       "SPARC     0.492968  0.593585  0.250510  0.251116  1.000000  0.299277   \n",
+       "\n",
+       "             EPAS1     PALLD      PHC2  LGALS3BP  ...      LDHB      LDHC  \\\n",
+       "GAS6      0.694218  0.598491  0.599584  0.595290  ...  0.096758  0.319135   \n",
+       "MMP14     0.652577  0.566899  0.596954  0.591671  ...  0.108111  0.328656   \n",
+       "DSP       0.570500  0.603818  0.261268  0.483510  ...  0.102505  0.322113   \n",
+       "MARCKSL1  0.254586  0.286491  0.441862  0.339611  ...  0.386577  0.314713   \n",
+       "SPARC     0.404538  0.481395  0.353212  0.426300  ...  0.259254  0.219185   \n",
+       "\n",
+       "             ACAP2     ACAP3      CFL2      CFL1      NFIB   PLEKHG6  \\\n",
+       "GAS6      0.243757  0.669781  0.433053  0.397045  0.298712  0.484416   \n",
+       "MMP14     0.295322  0.573781  0.372953  0.388056  0.232660  0.498833   \n",
+       "DSP       0.181120  0.336312  0.389993  0.143608  0.396473  0.567024   \n",
+       "MARCKSL1  0.302932  0.548047  0.313833  0.454887  0.228858  0.352535   \n",
+       "SPARC     0.128572  0.276951  0.441842  0.182518  0.339385  0.180845   \n",
+       "\n",
+       "             GNGT2  SERPINH1  \n",
+       "GAS6      0.357766  0.689587  \n",
+       "MMP14     0.371384  0.707476  \n",
+       "DSP       0.022467  0.615777  \n",
+       "MARCKSL1  0.312589  0.478413  \n",
+       "SPARC     0.240672  0.503508  \n",
+       "\n",
+       "[5 rows x 6750 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data_corrs.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:18:10.372393Z",
-     "iopub.status.busy": "2021-09-09T16:18:10.371925Z",
-     "iopub.status.idle": "2021-09-09T16:18:10.373986Z",
-     "shell.execute_reply": "2021-09-09T16:18:10.374338Z"
+     "iopub.execute_input": "2021-09-09T17:42:53.563502Z",
+     "iopub.status.busy": "2021-09-09T17:42:53.562928Z",
+     "iopub.status.idle": "2021-09-09T17:42:53.565936Z",
+     "shell.execute_reply": "2021-09-09T17:42:53.565500Z"
     },
     "papermill": {
-     "duration": 0.022338,
-     "end_time": "2021-09-09T16:18:10.374461",
+     "duration": 0.023828,
+     "end_time": "2021-09-09T17:42:53.566044",
      "exception": false,
-     "start_time": "2021-09-09T16:18:10.352123",
+     "start_time": "2021-09-09T17:42:53.542216",
      "status": "completed"
     },
     "tags": []
@@ -1210,20 +1457,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "b3c49a1a-bdf4-4cf9-824d-0d5c0acf2b73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-09-09T16:18:10.410176Z",
-     "iopub.status.busy": "2021-09-09T16:18:10.409711Z",
-     "iopub.status.idle": "2021-09-09T16:18:10.607711Z",
-     "shell.execute_reply": "2021-09-09T16:18:10.607253Z"
+     "iopub.execute_input": "2021-09-09T17:42:53.603594Z",
+     "iopub.status.busy": "2021-09-09T17:42:53.603156Z",
+     "iopub.status.idle": "2021-09-09T17:42:55.513107Z",
+     "shell.execute_reply": "2021-09-09T17:42:55.514557Z"
     },
     "papermill": {
-     "duration": 0.217088,
-     "end_time": "2021-09-09T16:18:10.607819",
+     "duration": 1.93164,
+     "end_time": "2021-09-09T17:42:55.515022",
      "exception": false,
-     "start_time": "2021-09-09T16:18:10.390731",
+     "start_time": "2021-09-09T17:42:53.583382",
      "status": "completed"
     },
     "tags": []
@@ -1240,10 +1487,10 @@
    "id": "258babdf-03ce-4450-ab22-7a3d75bf6869",
    "metadata": {
     "papermill": {
-     "duration": 0.01582,
-     "end_time": "2021-09-09T16:18:10.640608",
+     "duration": 0.018034,
+     "end_time": "2021-09-09T17:42:55.580388",
      "exception": false,
-     "start_time": "2021-09-09T16:18:10.624788",
+     "start_time": "2021-09-09T17:42:55.562354",
      "status": "completed"
     },
     "tags": []
@@ -1254,13 +1501,7 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1277,18 +1518,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 703.445278,
-   "end_time": "2021-09-09T16:18:10.963712",
+   "duration": 730.878031,
+   "end_time": "2021-09-09T17:42:55.907727",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb",
    "output_path": "nbs/10_compute_correlations/10_recount2/06-recount2-spearman.run.ipynb",
    "parameters": {},
-   "start_time": "2021-09-09T16:06:27.518434",
+   "start_time": "2021-09-09T17:30:45.029696",
    "version": "2.3.3"
   },
   "toc-autonumbering": true

--- a/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
+++ b/nbs/10_compute_correlations/10_recount2/06-recount2-spearman.ipynb
@@ -77,7 +77,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from tqdm import tqdm\n",
     "\n",
     "from clustermatch import conf\n",
     "from clustermatch.corr import spearman"
@@ -1153,6 +1152,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "bd93f2d7-d1fe-46c5-9a8c-92cac91ef7c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(data_corrs.shape)\n",
+    "\n",
+    "assert data.shape[0] == data_corrs.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da4f952a-539d-4007-bbfb-a57e426fb68a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_corrs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "id": "31e811b1-4329-494b-9905-ee002b34f4b4",
    "metadata": {
@@ -1233,7 +1254,13 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent",
+    "format_version": "1.3",
+    "jupytext_version": "1.11.5"
+   }
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1250,7 +1277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6"
   },
   "papermill": {
    "default_parameters": {},

--- a/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
+++ b/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
@@ -68,10 +68,10 @@ display(OUTPUT_DIR)
 # %% tags=[]
 data = pd.read_pickle(INPUT_FILE)
 
-# %%
+# %% tags=[]
 data.shape
 
-# %%
+# %% tags=[]
 data.head()
 
 # %% [markdown] tags=[]
@@ -105,15 +105,15 @@ display(_tmp)
 # %% [markdown] tags=[]
 # ## Run
 
-# %%
+# %% tags=[]
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
 
-# %%
+# %% tags=[]
 output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"
 display(output_filename)
 
-# %%
+# %% tags=[]
 # save
 data_corrs.to_pickle(output_filename)
 

--- a/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
+++ b/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
@@ -1,0 +1,120 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown] tags=[]
+# # Description
+
+# %% [markdown] tags=[]
+# According to the settings specified below, this notebook:
+#  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
+#  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
+#  3. computes the correlation matrix across all the genes using the correlation coefficient specified.
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %% tags=[]
+import pandas as pd
+from tqdm import tqdm
+
+from clustermatch import conf
+from clustermatch.corr import pearson
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %% tags=[]
+# we don't have gene subsets for recount2
+# GENE_SELECTION_STRATEGY = "var_raw"
+
+# %% tags=[]
+CORRELATION_METHOD = pearson
+
+method_name = CORRELATION_METHOD.__name__
+display(method_name)
+
+# %% tags=[]
+PERFORMANCE_TEST_N_TOP_GENES = 500
+
+# %% [markdown] tags=[]
+# # Paths
+
+# %% tags=[]
+INPUT_FILE = conf.RECOUNT2["DATA_FILE"]
+display(INPUT_FILE)
+
+assert INPUT_FILE.exists()
+
+# %% tags=[]
+OUTPUT_DIR = conf.RECOUNT2["SIMILARITY_MATRICES_DIR"]
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+display(OUTPUT_DIR)
+
+# %% [markdown] tags=[]
+# # Data loading
+
+# %% tags=[]
+data = pd.read_pickle(INPUT_FILE)
+
+# %%
+data.shape
+
+# %%
+data.head()
+
+# %% [markdown] tags=[]
+# # Compute similarity
+
+# %% [markdown] tags=[]
+# ## Performance test
+
+# %% tags=[]
+# select a subset of the genes
+test_data = data.sample(n=PERFORMANCE_TEST_N_TOP_GENES, random_state=0)
+
+# %% tags=[]
+test_data.shape
+
+# %% tags=[]
+test_data.head()
+
+# %% [markdown] tags=[]
+# This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
+
+# %% tags=[]
+_tmp = CORRELATION_METHOD(test_data.iloc[:3])
+
+display(_tmp.shape)
+display(_tmp)
+
+# %% tags=[]
+# %timeit CORRELATION_METHOD(test_data)
+
+# %% [markdown] tags=[]
+# ## Run
+
+# %%
+# compute correlations
+data_corrs = CORRELATION_METHOD(data)
+
+# %%
+output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"
+display(output_filename)
+
+# %%
+# save
+data_corrs.to_pickle(output_filename)
+
+# %% tags=[]

--- a/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
+++ b/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
@@ -108,12 +108,12 @@ display(_tmp)
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
 
-# %%
+# %% tags=[]
 display(data_corrs.shape)
 
 assert data.shape[0] == data_corrs.shape[0]
 
-# %%
+# %% tags=[]
 data_corrs.head()
 
 # %% tags=[]

--- a/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
+++ b/nbs/10_compute_correlations/10_recount2/py/05-recount2-pearson.py
@@ -27,7 +27,6 @@
 
 # %% tags=[]
 import pandas as pd
-from tqdm import tqdm
 
 from clustermatch import conf
 from clustermatch.corr import pearson
@@ -108,6 +107,14 @@ display(_tmp)
 # %% tags=[]
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
+
+# %%
+display(data_corrs.shape)
+
+assert data.shape[0] == data_corrs.shape[0]
+
+# %%
+data_corrs.head()
 
 # %% tags=[]
 output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"

--- a/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
+++ b/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
@@ -68,10 +68,10 @@ display(OUTPUT_DIR)
 # %% tags=[]
 data = pd.read_pickle(INPUT_FILE)
 
-# %%
+# %% tags=[]
 data.shape
 
-# %%
+# %% tags=[]
 data.head()
 
 # %% [markdown] tags=[]
@@ -105,15 +105,15 @@ display(_tmp)
 # %% [markdown] tags=[]
 # ## Run
 
-# %%
+# %% tags=[]
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
 
-# %%
+# %% tags=[]
 output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"
 display(output_filename)
 
-# %%
+# %% tags=[]
 # save
 data_corrs.to_pickle(output_filename)
 

--- a/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
+++ b/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
@@ -27,7 +27,6 @@
 
 # %% tags=[]
 import pandas as pd
-from tqdm import tqdm
 
 from clustermatch import conf
 from clustermatch.corr import spearman
@@ -108,6 +107,14 @@ display(_tmp)
 # %% tags=[]
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
+
+# %%
+display(data_corrs.shape)
+
+assert data.shape[0] == data_corrs.shape[0]
+
+# %%
+data_corrs.head()
 
 # %% tags=[]
 output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"

--- a/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
+++ b/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
@@ -1,0 +1,120 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown] tags=[]
+# # Description
+
+# %% [markdown] tags=[]
+# According to the settings specified below, this notebook:
+#  1. reads all the data from one source (GTEx, recount2, etc) according to the gene selection method (`GENE_SELECTION_STRATEGY`),
+#  2. runs a quick performance test using the correlation coefficient specified (`CORRELATION_METHOD`), and
+#  3. computes the correlation matrix across all the genes using the correlation coefficient specified.
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %% tags=[]
+import pandas as pd
+from tqdm import tqdm
+
+from clustermatch import conf
+from clustermatch.corr import spearman
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %% tags=[]
+# we don't have gene subsets for recount2
+# GENE_SELECTION_STRATEGY = "var_raw"
+
+# %% tags=[]
+CORRELATION_METHOD = spearman
+
+method_name = CORRELATION_METHOD.__name__
+display(method_name)
+
+# %% tags=[]
+PERFORMANCE_TEST_N_TOP_GENES = 500
+
+# %% [markdown] tags=[]
+# # Paths
+
+# %% tags=[]
+INPUT_FILE = conf.RECOUNT2["DATA_FILE"]
+display(INPUT_FILE)
+
+assert INPUT_FILE.exists()
+
+# %% tags=[]
+OUTPUT_DIR = conf.RECOUNT2["SIMILARITY_MATRICES_DIR"]
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+display(OUTPUT_DIR)
+
+# %% [markdown] tags=[]
+# # Data loading
+
+# %% tags=[]
+data = pd.read_pickle(INPUT_FILE)
+
+# %%
+data.shape
+
+# %%
+data.head()
+
+# %% [markdown] tags=[]
+# # Compute similarity
+
+# %% [markdown] tags=[]
+# ## Performance test
+
+# %% tags=[]
+# select a subset of the genes
+test_data = data.sample(n=PERFORMANCE_TEST_N_TOP_GENES, random_state=0)
+
+# %% tags=[]
+test_data.shape
+
+# %% tags=[]
+test_data.head()
+
+# %% [markdown] tags=[]
+# This is a quick performance test of the correlation measure. The following line (`_tmp = ...`) is the setup code, which is needed in case the correlation method was optimized using `numba` and needs to be compiled before performing the test.
+
+# %% tags=[]
+_tmp = CORRELATION_METHOD(test_data.iloc[:3])
+
+display(_tmp.shape)
+display(_tmp)
+
+# %% tags=[]
+# %timeit CORRELATION_METHOD(test_data)
+
+# %% [markdown] tags=[]
+# ## Run
+
+# %%
+# compute correlations
+data_corrs = CORRELATION_METHOD(data)
+
+# %%
+output_filename = OUTPUT_DIR / f"{INPUT_FILE.stem}-{method_name}.pkl"
+display(output_filename)
+
+# %%
+# save
+data_corrs.to_pickle(output_filename)
+
+# %% tags=[]

--- a/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
+++ b/nbs/10_compute_correlations/10_recount2/py/06-recount2-spearman.py
@@ -108,12 +108,12 @@ display(_tmp)
 # compute correlations
 data_corrs = CORRELATION_METHOD(data)
 
-# %%
+# %% tags=[]
 display(data_corrs.shape)
 
 assert data.shape[0] == data_corrs.shape[0]
 
-# %%
+# %% tags=[]
 data_corrs.head()
 
 # %% tags=[]

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This file exports some common environmental variables to run the code.  It
+# has to be customized for your need by changing the BASE_DIR and CM_N_JOBS
+# below.
+
+# Your settings here
+# BASE_DIR is the parent directory where the code and manuscript repos are
+# located.
+BASE_DIR=/home/miltondp/projects/labs/greenelab/clustermatch_repos
+export CM_N_JOBS=2
+
+export CM_ROOT_DIR=${BASE_DIR}/clustermatch-gene-expr/base
+export CM_MANUSCRIPT_DIR=${BASE_DIR}/clustermatch-gene-expr-manuscript/
+
+export PYTHONPATH=${BASE_DIR}/clustermatch-gene-expr/libs/
+
+echo "now execute: conda activate"
+

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -8,12 +8,10 @@
 # BASE_DIR is the parent directory where the code and manuscript repos are
 # located.
 BASE_DIR=/home/miltondp/projects/labs/greenelab/clustermatch_repos
-export CM_N_JOBS=2
+export CM_N_JOBS=3
 
 export CM_ROOT_DIR=${BASE_DIR}/clustermatch-gene-expr/base
 export CM_MANUSCRIPT_DIR=${BASE_DIR}/clustermatch-gene-expr-manuscript/
 
 export PYTHONPATH=${BASE_DIR}/clustermatch-gene-expr/libs/
-
-echo "now execute: conda activate"
 

--- a/scripts/run_docker_dev.sh
+++ b/scripts/run_docker_dev.sh
@@ -8,21 +8,45 @@
 # Plus, the code is always run inside the same environment (including the full
 # operating system).
 
-CODE_DIR="/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr"
-DATA_DIR="${CODE_DIR}/base"
-MANUSCRIPT_DIR="/home/miltondp/projects/labs/greenelab/clustermatch_repos/clustermatch-gene-expr-manuscript"
-N_JOBS=3
+# We assume the repo code is in the current directory, so the user has to make
+# sure this is right.
+
+echo "Configuration:"
+
+CODE_DIR=`pwd`
+echo "  Code dir: ${CODE_DIR}"
+
+if [ -z "${CM_ROOT_DIR}" ]; then
+  ROOT_DIR="${CODE_DIR}/base"
+else
+  ROOT_DIR="${CM_ROOT_DIR}"
+fi
+
+echo "  Root dir: ${ROOT_DIR}"
+
+if [ -z "${CM_MANUSCRIPT_DIR}" ]; then
+  echo "  ERROR: manuscript directory is not set"
+  exit 1
+fi
+
+echo "  Manuscript dir: ${CM_MANUSCRIPT_DIR}"
+
+echo "  CPU cores: ${CM_N_JOBS}"
+
+echo ""
+echo "Waiting 5 seconds before starting"
+sleep 5
 
 # always create data directory before running Docker
-mkdir -p ${DATA_DIR}
+mkdir -p ${ROOT_DIR}
 
 COMMAND="$@"
 
 docker run --rm \
-  -e CM_N_JOBS=${N_JOBS} \
+  -e CM_N_JOBS=${CM_N_JOBS} \
   -v "${CODE_DIR}:/opt/code" \
-  -v "${DATA_DIR}:/opt/data" \
-  -v "${MANUSCRIPT_DIR}:/opt/manuscript" \
+  -v "${ROOT_DIR}:/opt/data" \
+  -v "${CM_MANUSCRIPT_DIR}:/opt/manuscript" \
   --user "$(id -u):$(id -g)" \
   miltondp/clustermatch_gene_expr \
   /bin/bash -c "${COMMAND}"


### PR DESCRIPTION
This PR adds notebooks to process gene expression data from recount2 as used in the MultiPLIER paper. Most of the code used is very similar to the already reviewed code that processes GTEx data.

The main files to review are:
* `environment/scripts/setup_data.py`:  the script now has a function that downloads a zip file and extracts a particular file inside it. I'm using it to download the recount2 data.
* `nbs/05_preprocessing/py/10-recount2_multiplier-format.py`: saves the recount2 data into a pkl file.
* `nbs/10_compute_correlations/10_recount2/py/05-recount2-[pearson|spearman].py`: two notebooks that compute the pearson and spearman correlation coefficients on recount2.