### PR TITLE
Fix Clustermatch coefficient issues

### DIFF
--- a/libs/clustermatch/coef.py
+++ b/libs/clustermatch/coef.py
@@ -52,7 +52,7 @@ def run_quantile_clustering(data: NDArray, k: int) -> NDArray[np.int16]:
     """
     data_sorted = np.argsort(data, kind="quicksort")
     data_rank = rank(data, data_sorted)
-    data_perc = data_rank / data_rank.max()
+    data_perc = data_rank / len(data)
 
     percentiles = [0.0] + _get_perc_from_k(k) + [1.0]
 

--- a/libs/clustermatch/scipy/stats.py
+++ b/libs/clustermatch/scipy/stats.py
@@ -66,7 +66,7 @@ from numpy.typing import NDArray
 def rank(data: NDArray, sorted_data_idx: NDArray = None) -> NDArray:
     """
     It returns the ranks of a numpy array. It's an implementation based on
-    scipy.stats.rankdata (method="dense") that can be compiled by numba.
+    scipy.stats.rankdata (method="average") that can be compiled by numba.
 
     Args:
         data: a 1d array with numeric data.
@@ -89,4 +89,11 @@ def rank(data: NDArray, sorted_data_idx: NDArray = None) -> NDArray:
     arr = arr[sorter]
     obs = np.ones(arr.shape[0], dtype=np.bool_)
     obs[1:] = arr[1:] != arr[:-1]
-    return obs.cumsum()[inv]
+    dense = obs.cumsum()[inv]
+
+    obs_nz = np.nonzero(obs)[0]
+    count = np.zeros(obs_nz.shape[0] + 1, dtype=np.int64)
+    count[:-1] = obs_nz
+    count[-1] = len(obs)
+
+    return .5 * (count[dense] + count[dense - 1] + 1)

--- a/libs/clustermatch/scipy/stats.py
+++ b/libs/clustermatch/scipy/stats.py
@@ -96,4 +96,4 @@ def rank(data: NDArray, sorted_data_idx: NDArray = None) -> NDArray:
     count[:-1] = obs_nz
     count[-1] = len(obs)
 
-    return .5 * (count[dense] + count[dense - 1] + 1)
+    return 0.5 * (count[dense] + count[dense - 1] + 1)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-cdist_parts_v04.ipynb
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-cdist_parts_v04.ipynb
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "18.5 ms ± 458 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "17.3 ms ± 647 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -336,32 +336,32 @@
     {
      "data": {
       "text/plain": [
-       "         6942 function calls in 0.032 seconds\n",
+       "         6815 function calls in 0.028 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    0.032    0.032 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    0.032    0.032 <string>:1(<module>)\n",
-       "        1    0.000    0.000    0.032    0.032 1517976664.py:1(func)\n",
-       "       10    0.001    0.000    0.032    0.003 coef.py:252(cm)\n",
-       "       10    0.001    0.000    0.023    0.002 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    0.022    0.002 coef.py:380(cdist_func)\n",
-       "       10    0.002    0.000    0.022    0.002 coef.py:168(cdist_parts_parallel)\n",
-       "      135    0.001    0.000    0.018    0.000 threading.py:280(wait)\n",
-       "      558    0.017    0.000    0.017    0.000 {method 'acquire' of '_thread.lock' objects}\n",
-       "       72    0.000    0.000    0.017    0.000 threading.py:556(wait)\n",
-       "       70    0.001    0.000    0.014    0.000 _base.py:201(as_completed)\n",
-       "       80    0.000    0.000    0.009    0.000 thread.py:155(submit)\n",
-       "       80    0.000    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)\n",
-       "       30    0.000    0.000    0.006    0.000 threading.py:873(start)\n",
-       "       10    0.001    0.000    0.005    0.001 coef.py:178(<dictcomp>)\n",
-       "       10    0.000    0.000    0.005    0.000 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.005    0.000 _base.py:597(<listcomp>)\n",
+       "        1    0.000    0.000    0.028    0.028 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    0.028    0.028 <string>:1(<module>)\n",
+       "        1    0.000    0.000    0.028    0.028 1517976664.py:1(func)\n",
+       "       10    0.001    0.000    0.028    0.003 coef.py:275(cm)\n",
+       "       10    0.001    0.000    0.020    0.002 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    0.019    0.002 coef.py:407(cdist_func)\n",
+       "       10    0.002    0.000    0.019    0.002 coef.py:168(cdist_parts_parallel)\n",
+       "      132    0.001    0.000    0.015    0.000 threading.py:280(wait)\n",
+       "      540    0.015    0.000    0.015    0.000 {method 'acquire' of '_thread.lock' objects}\n",
+       "       65    0.000    0.000    0.014    0.000 threading.py:556(wait)\n",
+       "       70    0.000    0.000    0.012    0.000 _base.py:201(as_completed)\n",
+       "       80    0.000    0.000    0.007    0.000 thread.py:155(submit)\n",
+       "       80    0.000    0.000    0.006    0.000 thread.py:174(_adjust_thread_count)\n",
+       "       30    0.000    0.000    0.004    0.000 threading.py:873(start)\n",
+       "       10    0.000    0.000    0.004    0.000 coef.py:186(<dictcomp>)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)\n",
+       "       80    0.000    0.000    0.001    0.000 _base.py:417(result)\n",
        "       10    0.000    0.000    0.001    0.000 _base.py:635(__exit__)\n",
-       "       10    0.000    0.000    0.001    0.000 thread.py:210(shutdown)\n",
-       "       30    0.000    0.000    0.001    0.000 threading.py:1021(join)"
+       "       10    0.000    0.000    0.001    0.000 thread.py:210(shutdown)"
       ]
      },
      "metadata": {},
@@ -451,7 +451,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "45.7 ms ± 536 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "34 ms ± 878 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -486,32 +486,32 @@
     {
      "data": {
       "text/plain": [
-       "         9232 function calls in 0.065 seconds\n",
+       "         9175 function calls in 0.046 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    0.065    0.065 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    0.065    0.065 <string>:1(<module>)\n",
-       "        1    0.000    0.000    0.065    0.065 1517976664.py:1(func)\n",
-       "       10    0.001    0.000    0.065    0.006 coef.py:252(cm)\n",
-       "       10    0.001    0.000    0.050    0.005 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    0.049    0.005 coef.py:380(cdist_func)\n",
-       "       10    0.005    0.000    0.048    0.005 coef.py:168(cdist_parts_parallel)\n",
-       "      808    0.041    0.000    0.041    0.000 {method 'acquire' of '_thread.lock' objects}\n",
-       "      200    0.001    0.000    0.040    0.000 threading.py:280(wait)\n",
-       "      106    0.000    0.000    0.038    0.000 threading.py:556(wait)\n",
-       "      100    0.001    0.000    0.036    0.000 _base.py:201(as_completed)\n",
-       "      110    0.001    0.000    0.011    0.000 thread.py:155(submit)\n",
-       "      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)\n",
-       "       10    0.001    0.000    0.007    0.001 coef.py:178(<dictcomp>)\n",
-       "       30    0.000    0.000    0.006    0.000 threading.py:873(start)\n",
-       "       10    0.000    0.000    0.006    0.001 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.006    0.001 _base.py:597(<listcomp>)\n",
-       "       10    0.000    0.000    0.004    0.000 _base.py:635(__exit__)\n",
-       "       10    0.000    0.000    0.004    0.000 thread.py:210(shutdown)\n",
-       "       30    0.000    0.000    0.004    0.000 threading.py:1021(join)"
+       "        1    0.000    0.000    0.046    0.046 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    0.046    0.046 <string>:1(<module>)\n",
+       "        1    0.000    0.000    0.046    0.046 1517976664.py:1(func)\n",
+       "       10    0.001    0.000    0.045    0.005 coef.py:275(cm)\n",
+       "       10    0.001    0.000    0.037    0.004 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    0.036    0.004 coef.py:407(cdist_func)\n",
+       "       10    0.002    0.000    0.036    0.004 coef.py:168(cdist_parts_parallel)\n",
+       "      203    0.001    0.000    0.030    0.000 threading.py:280(wait)\n",
+       "      810    0.029    0.000    0.029    0.000 {method 'acquire' of '_thread.lock' objects}\n",
+       "      100    0.000    0.000    0.028    0.000 threading.py:556(wait)\n",
+       "      100    0.001    0.000    0.027    0.000 _base.py:201(as_completed)\n",
+       "      110    0.001    0.000    0.009    0.000 thread.py:155(submit)\n",
+       "      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)\n",
+       "       10    0.001    0.000    0.006    0.001 coef.py:186(<dictcomp>)\n",
+       "       30    0.000    0.000    0.005    0.000 threading.py:873(start)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)\n",
+       "      110    0.000    0.000    0.002    0.000 _base.py:417(result)\n",
+       "      110    0.000    0.000    0.002    0.000 threading.py:404(acquire)\n",
+       "       30    0.000    0.000    0.001    0.000 _base.py:601(result_iterator)"
       ]
      },
      "metadata": {},
@@ -601,7 +601,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "63.6 ms ± 3.95 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "49.8 ms ± 422 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -636,32 +636,32 @@
     {
      "data": {
       "text/plain": [
-       "         9358 function calls in 0.082 seconds\n",
+       "         9391 function calls in 0.062 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    0.082    0.082 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    0.082    0.082 <string>:1(<module>)\n",
-       "        1    0.000    0.000    0.082    0.082 1517976664.py:1(func)\n",
-       "       10    0.001    0.000    0.081    0.008 coef.py:252(cm)\n",
-       "       10    0.001    0.000    0.064    0.006 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    0.062    0.006 coef.py:380(cdist_func)\n",
-       "       10    0.003    0.000    0.062    0.006 coef.py:168(cdist_parts_parallel)\n",
-       "      213    0.001    0.000    0.060    0.000 threading.py:280(wait)\n",
-       "      844    0.059    0.000    0.059    0.000 {method 'acquire' of '_thread.lock' objects}\n",
-       "      107    0.000    0.000    0.053    0.000 threading.py:556(wait)\n",
-       "      100    0.001    0.000    0.052    0.001 _base.py:201(as_completed)\n",
-       "      110    0.001    0.000    0.010    0.000 thread.py:155(submit)\n",
-       "      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)\n",
-       "      110    0.000    0.000    0.008    0.000 _base.py:417(result)\n",
-       "       30    0.000    0.000    0.008    0.000 _base.py:601(result_iterator)\n",
-       "       10    0.001    0.000    0.006    0.001 coef.py:178(<dictcomp>)\n",
-       "       30    0.000    0.000    0.005    0.000 threading.py:873(start)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)\n",
-       "      110    0.001    0.000    0.002    0.000 threading.py:404(acquire)"
+       "        1    0.000    0.000    0.062    0.062 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    0.062    0.062 <string>:1(<module>)\n",
+       "        1    0.000    0.000    0.062    0.062 1517976664.py:1(func)\n",
+       "       10    0.001    0.000    0.062    0.006 coef.py:275(cm)\n",
+       "       10    0.001    0.000    0.048    0.005 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    0.047    0.005 coef.py:407(cdist_func)\n",
+       "       10    0.002    0.000    0.047    0.005 coef.py:168(cdist_parts_parallel)\n",
+       "      215    0.001    0.000    0.045    0.000 threading.py:280(wait)\n",
+       "      850    0.045    0.000    0.045    0.000 {method 'acquire' of '_thread.lock' objects}\n",
+       "      108    0.000    0.000    0.040    0.000 threading.py:556(wait)\n",
+       "      100    0.001    0.000    0.039    0.000 _base.py:201(as_completed)\n",
+       "      110    0.001    0.000    0.008    0.000 thread.py:155(submit)\n",
+       "      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)\n",
+       "      110    0.000    0.000    0.006    0.000 _base.py:417(result)\n",
+       "       30    0.000    0.000    0.006    0.000 _base.py:601(result_iterator)\n",
+       "       10    0.001    0.000    0.006    0.001 coef.py:186(<dictcomp>)\n",
+       "       30    0.000    0.000    0.004    0.000 threading.py:873(start)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)\n",
+       "      110    0.000    0.000    0.001    0.000 threading.py:404(acquire)"
       ]
      },
      "metadata": {},
@@ -751,7 +751,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "92.6 ms ± 2.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "69.3 ms ± 2.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -786,32 +786,32 @@
     {
      "data": {
       "text/plain": [
-       "         9578 function calls in 0.113 seconds\n",
+       "         9577 function calls in 0.083 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    0.113    0.113 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    0.113    0.113 <string>:1(<module>)\n",
-       "        1    0.000    0.000    0.113    0.113 1517976664.py:1(func)\n",
-       "       10    0.001    0.000    0.113    0.011 coef.py:252(cm)\n",
-       "      222    0.001    0.000    0.092    0.000 threading.py:280(wait)\n",
-       "      882    0.091    0.000    0.091    0.000 {method 'acquire' of '_thread.lock' objects}\n",
-       "       10    0.001    0.000    0.088    0.009 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    0.087    0.009 coef.py:380(cdist_func)\n",
-       "       10    0.002    0.000    0.087    0.009 coef.py:168(cdist_parts_parallel)\n",
-       "      116    0.001    0.000    0.079    0.001 threading.py:556(wait)\n",
-       "      100    0.001    0.000    0.077    0.001 _base.py:201(as_completed)\n",
-       "      110    0.000    0.000    0.015    0.000 _base.py:417(result)\n",
-       "       30    0.000    0.000    0.014    0.000 _base.py:601(result_iterator)\n",
-       "      110    0.001    0.000    0.011    0.000 thread.py:155(submit)\n",
-       "      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)\n",
-       "       10    0.001    0.000    0.007    0.001 coef.py:178(<dictcomp>)\n",
-       "       30    0.000    0.000    0.006    0.000 threading.py:873(start)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)\n",
-       "       10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)"
+       "        1    0.000    0.000    0.083    0.083 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    0.083    0.083 <string>:1(<module>)\n",
+       "        1    0.000    0.000    0.083    0.083 1517976664.py:1(func)\n",
+       "       10    0.001    0.000    0.083    0.008 coef.py:275(cm)\n",
+       "      223    0.001    0.000    0.066    0.000 threading.py:280(wait)\n",
+       "      882    0.065    0.000    0.065    0.000 {method 'acquire' of '_thread.lock' objects}\n",
+       "       10    0.001    0.000    0.064    0.006 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    0.063    0.006 coef.py:407(cdist_func)\n",
+       "       10    0.002    0.000    0.062    0.006 coef.py:168(cdist_parts_parallel)\n",
+       "      115    0.000    0.000    0.055    0.000 threading.py:556(wait)\n",
+       "      100    0.001    0.000    0.054    0.001 _base.py:201(as_completed)\n",
+       "      110    0.000    0.000    0.012    0.000 _base.py:417(result)\n",
+       "       30    0.000    0.000    0.011    0.000 _base.py:601(result_iterator)\n",
+       "      110    0.001    0.000    0.008    0.000 thread.py:155(submit)\n",
+       "      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)\n",
+       "       10    0.002    0.000    0.006    0.001 coef.py:186(<dictcomp>)\n",
+       "       30    0.000    0.000    0.005    0.000 threading.py:873(start)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)\n",
+       "      185    0.001    0.000    0.002    0.000 _base.py:179(_yield_finished_futures)"
       ]
      },
      "metadata": {},
@@ -918,7 +918,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.79 s ± 93.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.47 s ± 110 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -953,31 +953,31 @@
     {
      "data": {
       "text/plain": [
-       "         9639 function calls in 3.811 seconds\n",
+       "         9633 function calls in 2.469 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    3.811    3.811 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    3.811    3.811 <string>:1(<module>)\n",
-       "        1    0.000    0.000    3.811    3.811 1517976664.py:1(func)\n",
-       "       10    0.005    0.000    3.811    0.381 coef.py:252(cm)\n",
-       "      221    0.002    0.000    3.781    0.017 threading.py:280(wait)\n",
-       "      892    3.779    0.004    3.779    0.004 {method 'acquire' of '_thread.lock' objects}\n",
-       "       10    0.001    0.000    2.694    0.269 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    2.692    0.269 coef.py:380(cdist_func)\n",
-       "       10    0.002    0.000    2.692    0.269 coef.py:168(cdist_parts_parallel)\n",
-       "      120    0.001    0.000    2.680    0.022 threading.py:556(wait)\n",
-       "      100    0.002    0.000    2.680    0.027 _base.py:201(as_completed)\n",
-       "      110    0.001    0.000    1.102    0.010 _base.py:417(result)\n",
-       "       30    0.000    0.000    1.101    0.037 _base.py:601(result_iterator)\n",
-       "      110    0.001    0.000    0.011    0.000 thread.py:155(submit)\n",
-       "      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)\n",
-       "       10    0.003    0.000    0.009    0.001 coef.py:178(<dictcomp>)\n",
-       "       30    0.000    0.000    0.005    0.000 threading.py:873(start)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)\n",
+       "        1    0.000    0.000    2.469    2.469 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    2.469    2.469 <string>:1(<module>)\n",
+       "        1    0.000    0.000    2.469    2.469 1517976664.py:1(func)\n",
+       "       10    0.003    0.000    2.469    0.247 coef.py:275(cm)\n",
+       "      220    0.001    0.000    2.448    0.011 threading.py:280(wait)\n",
+       "      890    2.448    0.003    2.448    0.003 {method 'acquire' of '_thread.lock' objects}\n",
+       "       10    0.001    0.000    1.676    0.168 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    1.675    0.168 coef.py:407(cdist_func)\n",
+       "       10    0.001    0.000    1.675    0.167 coef.py:168(cdist_parts_parallel)\n",
+       "      120    0.000    0.000    1.668    0.014 threading.py:556(wait)\n",
+       "      100    0.001    0.000    1.667    0.017 _base.py:201(as_completed)\n",
+       "      110    0.000    0.000    0.781    0.007 _base.py:417(result)\n",
+       "       30    0.000    0.000    0.780    0.026 _base.py:601(result_iterator)\n",
+       "      110    0.001    0.000    0.008    0.000 thread.py:155(submit)\n",
+       "      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)\n",
+       "       10    0.002    0.000    0.006    0.001 coef.py:186(<dictcomp>)\n",
+       "       30    0.000    0.000    0.004    0.000 threading.py:873(start)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)\n",
        "       10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)"
       ]
      },
@@ -1068,7 +1068,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7.98 s ± 110 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "5.13 s ± 115 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1103,32 +1103,32 @@
     {
      "data": {
       "text/plain": [
-       "         9676 function calls in 8.328 seconds\n",
+       "         9647 function calls in 5.917 seconds\n",
        "\n",
        "   Ordered by: cumulative time\n",
        "   List reduced from 120 to 20 due to restriction <20>\n",
        "\n",
        "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-       "        1    0.000    0.000    8.328    8.328 {built-in method builtins.exec}\n",
-       "        1    0.000    0.000    8.328    8.328 <string>:1(<module>)\n",
-       "        1    0.000    0.000    8.328    8.328 1517976664.py:1(func)\n",
-       "       10    0.008    0.001    8.328    0.833 coef.py:252(cm)\n",
-       "      225    0.002    0.000    8.288    0.037 threading.py:280(wait)\n",
-       "      900    8.286    0.009    8.286    0.009 {method 'acquire' of '_thread.lock' objects}\n",
-       "       10    0.001    0.000    5.853    0.585 coef.py:387(compute_coef)\n",
-       "       10    0.000    0.000    5.851    0.585 coef.py:380(cdist_func)\n",
-       "       10    0.003    0.000    5.851    0.585 coef.py:168(cdist_parts_parallel)\n",
-       "      100    0.002    0.000    5.836    0.058 _base.py:201(as_completed)\n",
-       "      120    0.001    0.000    5.835    0.049 threading.py:556(wait)\n",
-       "      110    0.001    0.000    2.454    0.022 _base.py:417(result)\n",
-       "       30    0.000    0.000    2.453    0.082 _base.py:601(result_iterator)\n",
-       "      110    0.001    0.000    0.012    0.000 thread.py:155(submit)\n",
-       "       10    0.005    0.001    0.011    0.001 coef.py:178(<dictcomp>)\n",
-       "      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)\n",
-       "       10    0.000    0.000    0.006    0.001 _base.py:572(map)\n",
-       "       10    0.000    0.000    0.006    0.001 _base.py:597(<listcomp>)\n",
+       "        1    0.000    0.000    5.917    5.917 {built-in method builtins.exec}\n",
+       "        1    0.000    0.000    5.917    5.917 <string>:1(<module>)\n",
+       "        1    0.000    0.000    5.917    5.917 1517976664.py:1(func)\n",
+       "       10    0.005    0.001    5.917    0.592 coef.py:275(cm)\n",
+       "      222    0.001    0.000    5.890    0.027 threading.py:280(wait)\n",
+       "      894    5.889    0.007    5.889    0.007 {method 'acquire' of '_thread.lock' objects}\n",
+       "       10    0.001    0.000    4.013    0.401 coef.py:414(compute_coef)\n",
+       "       10    0.000    0.000    4.011    0.401 coef.py:407(cdist_func)\n",
+       "       10    0.002    0.000    4.011    0.401 coef.py:168(cdist_parts_parallel)\n",
+       "      120    0.000    0.000    4.002    0.033 threading.py:556(wait)\n",
+       "      100    0.001    0.000    4.001    0.040 _base.py:201(as_completed)\n",
+       "      110    0.000    0.000    1.888    0.017 _base.py:417(result)\n",
+       "       30    0.000    0.000    1.888    0.063 _base.py:601(result_iterator)\n",
+       "      110    0.001    0.000    0.010    0.000 thread.py:155(submit)\n",
+       "      110    0.001    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)\n",
+       "       10    0.003    0.000    0.008    0.001 coef.py:186(<dictcomp>)\n",
        "       30    0.000    0.000    0.005    0.000 threading.py:873(start)\n",
-       "       50    0.004    0.000    0.004    0.000 {built-in method numpy.zeros}"
+       "       10    0.000    0.000    0.005    0.000 _base.py:572(map)\n",
+       "       10    0.000    0.000    0.005    0.000 _base.py:597(<listcomp>)\n",
+       "       50    0.002    0.000    0.002    0.000 {built-in method numpy.zeros}"
       ]
      },
      "metadata": {},

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_large_100000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_large_100000.txt
@@ -1,26 +1,26 @@
-         9676 function calls in 8.328 seconds
+         9647 function calls in 5.917 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    8.328    8.328 {built-in method builtins.exec}
-        1    0.000    0.000    8.328    8.328 <string>:1(<module>)
-        1    0.000    0.000    8.328    8.328 1517976664.py:1(func)
-       10    0.008    0.001    8.328    0.833 coef.py:252(cm)
-      225    0.002    0.000    8.288    0.037 threading.py:280(wait)
-      900    8.286    0.009    8.286    0.009 {method 'acquire' of '_thread.lock' objects}
-       10    0.001    0.000    5.853    0.585 coef.py:387(compute_coef)
-       10    0.000    0.000    5.851    0.585 coef.py:380(cdist_func)
-       10    0.003    0.000    5.851    0.585 coef.py:168(cdist_parts_parallel)
-      100    0.002    0.000    5.836    0.058 _base.py:201(as_completed)
-      120    0.001    0.000    5.835    0.049 threading.py:556(wait)
-      110    0.001    0.000    2.454    0.022 _base.py:417(result)
-       30    0.000    0.000    2.453    0.082 _base.py:601(result_iterator)
-      110    0.001    0.000    0.012    0.000 thread.py:155(submit)
-       10    0.005    0.001    0.011    0.001 coef.py:178(<dictcomp>)
-      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)
-       10    0.000    0.000    0.006    0.001 _base.py:572(map)
-       10    0.000    0.000    0.006    0.001 _base.py:597(<listcomp>)
+        1    0.000    0.000    5.917    5.917 {built-in method builtins.exec}
+        1    0.000    0.000    5.917    5.917 <string>:1(<module>)
+        1    0.000    0.000    5.917    5.917 1517976664.py:1(func)
+       10    0.005    0.001    5.917    0.592 coef.py:275(cm)
+      222    0.001    0.000    5.890    0.027 threading.py:280(wait)
+      894    5.889    0.007    5.889    0.007 {method 'acquire' of '_thread.lock' objects}
+       10    0.001    0.000    4.013    0.401 coef.py:414(compute_coef)
+       10    0.000    0.000    4.011    0.401 coef.py:407(cdist_func)
+       10    0.002    0.000    4.011    0.401 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    4.002    0.033 threading.py:556(wait)
+      100    0.001    0.000    4.001    0.040 _base.py:201(as_completed)
+      110    0.000    0.000    1.888    0.017 _base.py:417(result)
+       30    0.000    0.000    1.888    0.063 _base.py:601(result_iterator)
+      110    0.001    0.000    0.010    0.000 thread.py:155(submit)
+      110    0.001    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)
+       10    0.003    0.000    0.008    0.001 coef.py:186(<dictcomp>)
        30    0.000    0.000    0.005    0.000 threading.py:873(start)
-       50    0.004    0.000    0.004    0.000 {built-in method numpy.zeros}
+       10    0.000    0.000    0.005    0.000 _base.py:572(map)
+       10    0.000    0.000    0.005    0.000 _base.py:597(<listcomp>)
+       50    0.002    0.000    0.002    0.000 {built-in method numpy.zeros}

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_large_50000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_large_50000.txt
@@ -1,26 +1,26 @@
-         9639 function calls in 3.811 seconds
+         9633 function calls in 2.469 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    3.811    3.811 {built-in method builtins.exec}
-        1    0.000    0.000    3.811    3.811 <string>:1(<module>)
-        1    0.000    0.000    3.811    3.811 1517976664.py:1(func)
-       10    0.005    0.000    3.811    0.381 coef.py:252(cm)
-      221    0.002    0.000    3.781    0.017 threading.py:280(wait)
-      892    3.779    0.004    3.779    0.004 {method 'acquire' of '_thread.lock' objects}
-       10    0.001    0.000    2.694    0.269 coef.py:387(compute_coef)
-       10    0.000    0.000    2.692    0.269 coef.py:380(cdist_func)
-       10    0.002    0.000    2.692    0.269 coef.py:168(cdist_parts_parallel)
-      120    0.001    0.000    2.680    0.022 threading.py:556(wait)
-      100    0.002    0.000    2.680    0.027 _base.py:201(as_completed)
-      110    0.001    0.000    1.102    0.010 _base.py:417(result)
-       30    0.000    0.000    1.101    0.037 _base.py:601(result_iterator)
-      110    0.001    0.000    0.011    0.000 thread.py:155(submit)
-      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)
-       10    0.003    0.000    0.009    0.001 coef.py:178(<dictcomp>)
-       30    0.000    0.000    0.005    0.000 threading.py:873(start)
-       10    0.000    0.000    0.005    0.001 _base.py:572(map)
-       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)
+        1    0.000    0.000    2.469    2.469 {built-in method builtins.exec}
+        1    0.000    0.000    2.469    2.469 <string>:1(<module>)
+        1    0.000    0.000    2.469    2.469 1517976664.py:1(func)
+       10    0.003    0.000    2.469    0.247 coef.py:275(cm)
+      220    0.001    0.000    2.448    0.011 threading.py:280(wait)
+      890    2.448    0.003    2.448    0.003 {method 'acquire' of '_thread.lock' objects}
+       10    0.001    0.000    1.676    0.168 coef.py:414(compute_coef)
+       10    0.000    0.000    1.675    0.168 coef.py:407(cdist_func)
+       10    0.001    0.000    1.675    0.167 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    1.668    0.014 threading.py:556(wait)
+      100    0.001    0.000    1.667    0.017 _base.py:201(as_completed)
+      110    0.000    0.000    0.781    0.007 _base.py:417(result)
+       30    0.000    0.000    0.780    0.026 _base.py:601(result_iterator)
+      110    0.001    0.000    0.008    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+       10    0.002    0.000    0.006    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.004    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
        10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_100.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_100.txt
@@ -1,26 +1,26 @@
-         9232 function calls in 0.065 seconds
+         9175 function calls in 0.046 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.065    0.065 {built-in method builtins.exec}
-        1    0.000    0.000    0.065    0.065 <string>:1(<module>)
-        1    0.000    0.000    0.065    0.065 1517976664.py:1(func)
-       10    0.001    0.000    0.065    0.006 coef.py:252(cm)
-       10    0.001    0.000    0.050    0.005 coef.py:387(compute_coef)
-       10    0.000    0.000    0.049    0.005 coef.py:380(cdist_func)
-       10    0.005    0.000    0.048    0.005 coef.py:168(cdist_parts_parallel)
-      808    0.041    0.000    0.041    0.000 {method 'acquire' of '_thread.lock' objects}
-      200    0.001    0.000    0.040    0.000 threading.py:280(wait)
-      106    0.000    0.000    0.038    0.000 threading.py:556(wait)
-      100    0.001    0.000    0.036    0.000 _base.py:201(as_completed)
-      110    0.001    0.000    0.011    0.000 thread.py:155(submit)
-      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)
-       10    0.001    0.000    0.007    0.001 coef.py:178(<dictcomp>)
-       30    0.000    0.000    0.006    0.000 threading.py:873(start)
-       10    0.000    0.000    0.006    0.001 _base.py:572(map)
-       10    0.000    0.000    0.006    0.001 _base.py:597(<listcomp>)
-       10    0.000    0.000    0.004    0.000 _base.py:635(__exit__)
-       10    0.000    0.000    0.004    0.000 thread.py:210(shutdown)
-       30    0.000    0.000    0.004    0.000 threading.py:1021(join)
+        1    0.000    0.000    0.046    0.046 {built-in method builtins.exec}
+        1    0.000    0.000    0.046    0.046 <string>:1(<module>)
+        1    0.000    0.000    0.046    0.046 1517976664.py:1(func)
+       10    0.001    0.000    0.045    0.005 coef.py:275(cm)
+       10    0.001    0.000    0.037    0.004 coef.py:414(compute_coef)
+       10    0.000    0.000    0.036    0.004 coef.py:407(cdist_func)
+       10    0.002    0.000    0.036    0.004 coef.py:168(cdist_parts_parallel)
+      203    0.001    0.000    0.030    0.000 threading.py:280(wait)
+      810    0.029    0.000    0.029    0.000 {method 'acquire' of '_thread.lock' objects}
+      100    0.000    0.000    0.028    0.000 threading.py:556(wait)
+      100    0.001    0.000    0.027    0.000 _base.py:201(as_completed)
+      110    0.001    0.000    0.009    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+       10    0.001    0.000    0.006    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.005    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+      110    0.000    0.000    0.002    0.000 _base.py:417(result)
+      110    0.000    0.000    0.002    0.000 threading.py:404(acquire)
+       30    0.000    0.000    0.001    0.000 _base.py:601(result_iterator)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_1000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_1000.txt
@@ -1,26 +1,26 @@
-         9578 function calls in 0.113 seconds
+         9577 function calls in 0.083 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.113    0.113 {built-in method builtins.exec}
-        1    0.000    0.000    0.113    0.113 <string>:1(<module>)
-        1    0.000    0.000    0.113    0.113 1517976664.py:1(func)
-       10    0.001    0.000    0.113    0.011 coef.py:252(cm)
-      222    0.001    0.000    0.092    0.000 threading.py:280(wait)
-      882    0.091    0.000    0.091    0.000 {method 'acquire' of '_thread.lock' objects}
-       10    0.001    0.000    0.088    0.009 coef.py:387(compute_coef)
-       10    0.000    0.000    0.087    0.009 coef.py:380(cdist_func)
-       10    0.002    0.000    0.087    0.009 coef.py:168(cdist_parts_parallel)
-      116    0.001    0.000    0.079    0.001 threading.py:556(wait)
-      100    0.001    0.000    0.077    0.001 _base.py:201(as_completed)
-      110    0.000    0.000    0.015    0.000 _base.py:417(result)
-       30    0.000    0.000    0.014    0.000 _base.py:601(result_iterator)
-      110    0.001    0.000    0.011    0.000 thread.py:155(submit)
-      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)
-       10    0.001    0.000    0.007    0.001 coef.py:178(<dictcomp>)
-       30    0.000    0.000    0.006    0.000 threading.py:873(start)
-       10    0.000    0.000    0.005    0.001 _base.py:572(map)
-       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)
-       10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)
+        1    0.000    0.000    0.083    0.083 {built-in method builtins.exec}
+        1    0.000    0.000    0.083    0.083 <string>:1(<module>)
+        1    0.000    0.000    0.083    0.083 1517976664.py:1(func)
+       10    0.001    0.000    0.083    0.008 coef.py:275(cm)
+      223    0.001    0.000    0.066    0.000 threading.py:280(wait)
+      882    0.065    0.000    0.065    0.000 {method 'acquire' of '_thread.lock' objects}
+       10    0.001    0.000    0.064    0.006 coef.py:414(compute_coef)
+       10    0.000    0.000    0.063    0.006 coef.py:407(cdist_func)
+       10    0.002    0.000    0.062    0.006 coef.py:168(cdist_parts_parallel)
+      115    0.000    0.000    0.055    0.000 threading.py:556(wait)
+      100    0.001    0.000    0.054    0.001 _base.py:201(as_completed)
+      110    0.000    0.000    0.012    0.000 _base.py:417(result)
+       30    0.000    0.000    0.011    0.000 _base.py:601(result_iterator)
+      110    0.001    0.000    0.008    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+       10    0.002    0.000    0.006    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.005    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+      185    0.001    0.000    0.002    0.000 _base.py:179(_yield_finished_futures)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_50.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_50.txt
@@ -1,26 +1,26 @@
-         6942 function calls in 0.032 seconds
+         6815 function calls in 0.028 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.032    0.032 {built-in method builtins.exec}
-        1    0.000    0.000    0.032    0.032 <string>:1(<module>)
-        1    0.000    0.000    0.032    0.032 1517976664.py:1(func)
-       10    0.001    0.000    0.032    0.003 coef.py:252(cm)
-       10    0.001    0.000    0.023    0.002 coef.py:387(compute_coef)
-       10    0.000    0.000    0.022    0.002 coef.py:380(cdist_func)
-       10    0.002    0.000    0.022    0.002 coef.py:168(cdist_parts_parallel)
-      135    0.001    0.000    0.018    0.000 threading.py:280(wait)
-      558    0.017    0.000    0.017    0.000 {method 'acquire' of '_thread.lock' objects}
-       72    0.000    0.000    0.017    0.000 threading.py:556(wait)
-       70    0.001    0.000    0.014    0.000 _base.py:201(as_completed)
-       80    0.000    0.000    0.009    0.000 thread.py:155(submit)
-       80    0.000    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.006    0.000 threading.py:873(start)
-       10    0.001    0.000    0.005    0.001 coef.py:178(<dictcomp>)
-       10    0.000    0.000    0.005    0.000 _base.py:572(map)
-       10    0.000    0.000    0.005    0.000 _base.py:597(<listcomp>)
+        1    0.000    0.000    0.028    0.028 {built-in method builtins.exec}
+        1    0.000    0.000    0.028    0.028 <string>:1(<module>)
+        1    0.000    0.000    0.028    0.028 1517976664.py:1(func)
+       10    0.001    0.000    0.028    0.003 coef.py:275(cm)
+       10    0.001    0.000    0.020    0.002 coef.py:414(compute_coef)
+       10    0.000    0.000    0.019    0.002 coef.py:407(cdist_func)
+       10    0.002    0.000    0.019    0.002 coef.py:168(cdist_parts_parallel)
+      132    0.001    0.000    0.015    0.000 threading.py:280(wait)
+      540    0.015    0.000    0.015    0.000 {method 'acquire' of '_thread.lock' objects}
+       65    0.000    0.000    0.014    0.000 threading.py:556(wait)
+       70    0.000    0.000    0.012    0.000 _base.py:201(as_completed)
+       80    0.000    0.000    0.007    0.000 thread.py:155(submit)
+       80    0.000    0.000    0.006    0.000 thread.py:174(_adjust_thread_count)
+       30    0.000    0.000    0.004    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 coef.py:186(<dictcomp>)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+       80    0.000    0.000    0.001    0.000 _base.py:417(result)
        10    0.000    0.000    0.001    0.000 _base.py:635(__exit__)
        10    0.000    0.000    0.001    0.000 thread.py:210(shutdown)
-       30    0.000    0.000    0.001    0.000 threading.py:1021(join)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_500.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/08-n_samples_small_500.txt
@@ -1,26 +1,26 @@
-         9358 function calls in 0.082 seconds
+         9391 function calls in 0.062 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.082    0.082 {built-in method builtins.exec}
-        1    0.000    0.000    0.082    0.082 <string>:1(<module>)
-        1    0.000    0.000    0.082    0.082 1517976664.py:1(func)
-       10    0.001    0.000    0.081    0.008 coef.py:252(cm)
-       10    0.001    0.000    0.064    0.006 coef.py:387(compute_coef)
-       10    0.000    0.000    0.062    0.006 coef.py:380(cdist_func)
-       10    0.003    0.000    0.062    0.006 coef.py:168(cdist_parts_parallel)
-      213    0.001    0.000    0.060    0.000 threading.py:280(wait)
-      844    0.059    0.000    0.059    0.000 {method 'acquire' of '_thread.lock' objects}
-      107    0.000    0.000    0.053    0.000 threading.py:556(wait)
-      100    0.001    0.000    0.052    0.001 _base.py:201(as_completed)
-      110    0.001    0.000    0.010    0.000 thread.py:155(submit)
-      110    0.001    0.000    0.009    0.000 thread.py:174(_adjust_thread_count)
-      110    0.000    0.000    0.008    0.000 _base.py:417(result)
-       30    0.000    0.000    0.008    0.000 _base.py:601(result_iterator)
-       10    0.001    0.000    0.006    0.001 coef.py:178(<dictcomp>)
-       30    0.000    0.000    0.005    0.000 threading.py:873(start)
-       10    0.000    0.000    0.005    0.001 _base.py:572(map)
-       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)
-      110    0.001    0.000    0.002    0.000 threading.py:404(acquire)
+        1    0.000    0.000    0.062    0.062 {built-in method builtins.exec}
+        1    0.000    0.000    0.062    0.062 <string>:1(<module>)
+        1    0.000    0.000    0.062    0.062 1517976664.py:1(func)
+       10    0.001    0.000    0.062    0.006 coef.py:275(cm)
+       10    0.001    0.000    0.048    0.005 coef.py:414(compute_coef)
+       10    0.000    0.000    0.047    0.005 coef.py:407(cdist_func)
+       10    0.002    0.000    0.047    0.005 coef.py:168(cdist_parts_parallel)
+      215    0.001    0.000    0.045    0.000 threading.py:280(wait)
+      850    0.045    0.000    0.045    0.000 {method 'acquire' of '_thread.lock' objects}
+      108    0.000    0.000    0.040    0.000 threading.py:556(wait)
+      100    0.001    0.000    0.039    0.000 _base.py:201(as_completed)
+      110    0.001    0.000    0.008    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+      110    0.000    0.000    0.006    0.000 _base.py:417(result)
+       30    0.000    0.000    0.006    0.000 _base.py:601(result_iterator)
+       10    0.001    0.000    0.006    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.004    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+      110    0.000    0.000    0.001    0.000 threading.py:404(acquire)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-cdist_parts_v04.ipynb
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-cdist_parts_v04.ipynb
@@ -5,10 +5,10 @@
    "id": "36c65ddb-8246-4b0c-a231-68a373acc2cf",
    "metadata": {
     "papermill": {
-     "duration": 0.127359,
-     "end_time": "2021-11-28T04:45:55.760556",
+     "duration": 0.095646,
+     "end_time": "2021-12-02T04:34:06.384775",
      "exception": false,
-     "start_time": "2021-11-28T04:45:55.633197",
+     "start_time": "2021-12-02T04:34:06.289129",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "337633a8-d03e-4509-b89d-f8daee598958",
    "metadata": {
     "papermill": {
-     "duration": 0.088971,
-     "end_time": "2021-11-28T04:45:55.939325",
+     "duration": 0.091407,
+     "end_time": "2021-12-02T04:34:06.566258",
      "exception": false,
-     "start_time": "2021-11-28T04:45:55.850354",
+     "start_time": "2021-12-02T04:34:06.474851",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "63c2b099-cc44-4fe2-93d1-40336e0a8466",
    "metadata": {
     "papermill": {
-     "duration": 0.08896,
-     "end_time": "2021-11-28T04:45:56.118470",
+     "duration": 0.09056,
+     "end_time": "2021-12-02T04:34:06.747753",
      "exception": false,
-     "start_time": "2021-11-28T04:45:56.029510",
+     "start_time": "2021-12-02T04:34:06.657193",
      "status": "completed"
     },
     "tags": []
@@ -57,16 +57,16 @@
    "id": "960c4ff0-2a73-4eaa-97d6-3269102233eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:45:56.305754Z",
-     "iopub.status.busy": "2021-11-28T04:45:56.305296Z",
-     "iopub.status.idle": "2021-11-28T04:45:56.898723Z",
-     "shell.execute_reply": "2021-11-28T04:45:56.896618Z"
+     "iopub.execute_input": "2021-12-02T04:34:06.942330Z",
+     "iopub.status.busy": "2021-12-02T04:34:06.941822Z",
+     "iopub.status.idle": "2021-12-02T04:34:07.534005Z",
+     "shell.execute_reply": "2021-12-02T04:34:07.531916Z"
     },
     "papermill": {
-     "duration": 0.691063,
-     "end_time": "2021-11-28T04:45:56.899139",
+     "duration": 0.696141,
+     "end_time": "2021-12-02T04:34:07.534420",
      "exception": false,
-     "start_time": "2021-11-28T04:45:56.208076",
+     "start_time": "2021-12-02T04:34:06.838279",
      "status": "completed"
     },
     "tags": []
@@ -90,16 +90,16 @@
    "id": "e18db58a-316a-445b-a376-8b2ec18e08d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:45:57.118442Z",
-     "iopub.status.busy": "2021-11-28T04:45:57.116591Z",
-     "iopub.status.idle": "2021-11-28T04:45:57.718804Z",
-     "shell.execute_reply": "2021-11-28T04:45:57.720361Z"
+     "iopub.execute_input": "2021-12-02T04:34:07.733067Z",
+     "iopub.status.busy": "2021-12-02T04:34:07.732593Z",
+     "iopub.status.idle": "2021-12-02T04:34:08.445221Z",
+     "shell.execute_reply": "2021-12-02T04:34:08.443302Z"
     },
     "papermill": {
-     "duration": 0.698912,
-     "end_time": "2021-11-28T04:45:57.720801",
+     "duration": 0.817887,
+     "end_time": "2021-12-02T04:34:08.445598",
      "exception": false,
-     "start_time": "2021-11-28T04:45:57.021889",
+     "start_time": "2021-12-02T04:34:07.627711",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "b54099b0-a990-4bbd-bcbd-e206eb0f0f0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:45:57.940935Z",
-     "iopub.status.busy": "2021-11-28T04:45:57.940450Z",
-     "iopub.status.idle": "2021-11-28T04:45:58.565755Z",
-     "shell.execute_reply": "2021-11-28T04:45:58.564034Z"
+     "iopub.execute_input": "2021-12-02T04:34:08.668700Z",
+     "iopub.status.busy": "2021-12-02T04:34:08.668226Z",
+     "iopub.status.idle": "2021-12-02T04:34:09.290588Z",
+     "shell.execute_reply": "2021-12-02T04:34:09.288752Z"
     },
     "papermill": {
-     "duration": 0.72049,
-     "end_time": "2021-11-28T04:45:58.566132",
+     "duration": 0.719545,
+     "end_time": "2021-12-02T04:34:09.290958",
      "exception": false,
-     "start_time": "2021-11-28T04:45:57.845642",
+     "start_time": "2021-12-02T04:34:08.571413",
      "status": "completed"
     },
     "tags": []
@@ -151,16 +151,16 @@
    "id": "7a9a8098-8160-46bf-8d83-bc398cbe2382",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:45:58.786684Z",
-     "iopub.status.busy": "2021-11-28T04:45:58.786219Z",
-     "iopub.status.idle": "2021-11-28T04:45:59.382340Z",
-     "shell.execute_reply": "2021-11-28T04:45:59.383785Z"
+     "iopub.execute_input": "2021-12-02T04:34:09.513928Z",
+     "iopub.status.busy": "2021-12-02T04:34:09.513465Z",
+     "iopub.status.idle": "2021-12-02T04:34:10.120602Z",
+     "shell.execute_reply": "2021-12-02T04:34:10.118684Z"
     },
     "papermill": {
-     "duration": 0.692761,
-     "end_time": "2021-11-28T04:45:59.384293",
+     "duration": 0.704384,
+     "end_time": "2021-12-02T04:34:10.120972",
      "exception": false,
-     "start_time": "2021-11-28T04:45:58.691532",
+     "start_time": "2021-12-02T04:34:09.416588",
      "status": "completed"
     },
     "tags": []
@@ -175,10 +175,10 @@
    "id": "c2251313-41ac-46fd-a845-0f209689ecf6",
    "metadata": {
     "papermill": {
-     "duration": 0.091457,
-     "end_time": "2021-11-28T04:45:59.574956",
+     "duration": 0.093051,
+     "end_time": "2021-12-02T04:34:10.338738",
      "exception": false,
-     "start_time": "2021-11-28T04:45:59.483499",
+     "start_time": "2021-12-02T04:34:10.245687",
      "status": "completed"
     },
     "tags": []
@@ -193,16 +193,16 @@
    "id": "987ef5f1-be49-4a6c-a4f4-b24a0a2094cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:45:59.762621Z",
-     "iopub.status.busy": "2021-11-28T04:45:59.762143Z",
-     "iopub.status.idle": "2021-11-28T04:46:00.082557Z",
-     "shell.execute_reply": "2021-11-28T04:46:00.082092Z"
+     "iopub.execute_input": "2021-12-02T04:34:10.528319Z",
+     "iopub.status.busy": "2021-12-02T04:34:10.527833Z",
+     "iopub.status.idle": "2021-12-02T04:34:10.845421Z",
+     "shell.execute_reply": "2021-12-02T04:34:10.845020Z"
     },
     "papermill": {
-     "duration": 0.416214,
-     "end_time": "2021-11-28T04:46:00.082651",
+     "duration": 0.414249,
+     "end_time": "2021-12-02T04:34:10.845518",
      "exception": false,
-     "start_time": "2021-11-28T04:45:59.666437",
+     "start_time": "2021-12-02T04:34:10.431269",
      "status": "completed"
     },
     "tags": []
@@ -219,10 +219,10 @@
    "id": "24399ccb-d33d-4bad-9baf-638c9c56feb2",
    "metadata": {
     "papermill": {
-     "duration": 0.090488,
-     "end_time": "2021-11-28T04:46:00.264513",
+     "duration": 0.095359,
+     "end_time": "2021-12-02T04:34:11.037941",
      "exception": false,
-     "start_time": "2021-11-28T04:46:00.174025",
+     "start_time": "2021-12-02T04:34:10.942582",
      "status": "completed"
     },
     "tags": []
@@ -237,16 +237,16 @@
    "id": "c609cefa-f513-4cf8-9573-367744e31c5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:00.456861Z",
-     "iopub.status.busy": "2021-11-28T04:46:00.456308Z",
-     "iopub.status.idle": "2021-11-28T04:46:00.457886Z",
-     "shell.execute_reply": "2021-11-28T04:46:00.458287Z"
+     "iopub.execute_input": "2021-12-02T04:34:11.224902Z",
+     "iopub.status.busy": "2021-12-02T04:34:11.224429Z",
+     "iopub.status.idle": "2021-12-02T04:34:11.226352Z",
+     "shell.execute_reply": "2021-12-02T04:34:11.226694Z"
     },
     "papermill": {
-     "duration": 0.101877,
-     "end_time": "2021-11-28T04:46:00.458422",
+     "duration": 0.097459,
+     "end_time": "2021-12-02T04:34:11.226809",
      "exception": false,
-     "start_time": "2021-11-28T04:46:00.356545",
+     "start_time": "2021-12-02T04:34:11.129350",
      "status": "completed"
     },
     "tags": []
@@ -262,16 +262,16 @@
    "id": "c0341a42-b8de-419f-ab37-1e4fee9dde75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:00.648174Z",
-     "iopub.status.busy": "2021-11-28T04:46:00.647655Z",
-     "iopub.status.idle": "2021-11-28T04:46:00.649840Z",
-     "shell.execute_reply": "2021-11-28T04:46:00.649407Z"
+     "iopub.execute_input": "2021-12-02T04:34:11.416790Z",
+     "iopub.status.busy": "2021-12-02T04:34:11.416353Z",
+     "iopub.status.idle": "2021-12-02T04:34:11.418488Z",
+     "shell.execute_reply": "2021-12-02T04:34:11.418030Z"
     },
     "papermill": {
-     "duration": 0.096541,
-     "end_time": "2021-11-28T04:46:00.649931",
+     "duration": 0.098372,
+     "end_time": "2021-12-02T04:34:11.418578",
      "exception": false,
-     "start_time": "2021-11-28T04:46:00.553390",
+     "start_time": "2021-12-02T04:34:11.320206",
      "status": "completed"
     },
     "tags": []
@@ -286,10 +286,10 @@
    "id": "6fd3067b-a4f7-475e-9575-20246934537d",
    "metadata": {
     "papermill": {
-     "duration": 0.091596,
-     "end_time": "2021-11-28T04:46:00.833202",
+     "duration": 0.092004,
+     "end_time": "2021-12-02T04:34:11.602824",
      "exception": false,
-     "start_time": "2021-11-28T04:46:00.741606",
+     "start_time": "2021-12-02T04:34:11.510820",
      "status": "completed"
     },
     "tags": []
@@ -304,16 +304,16 @@
    "id": "02e0507c-43ff-4693-8a3b-8ccd8f23168c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:01.018605Z",
-     "iopub.status.busy": "2021-11-28T04:46:01.018137Z",
-     "iopub.status.idle": "2021-11-28T04:46:09.634233Z",
-     "shell.execute_reply": "2021-11-28T04:46:09.633794Z"
+     "iopub.execute_input": "2021-12-02T04:34:11.790398Z",
+     "iopub.status.busy": "2021-12-02T04:34:11.789933Z",
+     "iopub.status.idle": "2021-12-02T04:34:20.454299Z",
+     "shell.execute_reply": "2021-12-02T04:34:20.453925Z"
     },
     "papermill": {
-     "duration": 8.710078,
-     "end_time": "2021-11-28T04:46:09.634329",
+     "duration": 8.760307,
+     "end_time": "2021-12-02T04:34:20.454396",
      "exception": false,
-     "start_time": "2021-11-28T04:46:00.924251",
+     "start_time": "2021-12-02T04:34:11.694089",
      "status": "completed"
     },
     "tags": []
@@ -340,10 +340,10 @@
    "id": "8549179d-1517-4a40-9a51-b95dc02d0fcc",
    "metadata": {
     "papermill": {
-     "duration": 0.092525,
-     "end_time": "2021-11-28T04:46:09.820157",
+     "duration": 0.092955,
+     "end_time": "2021-12-02T04:34:20.640996",
      "exception": false,
-     "start_time": "2021-11-28T04:46:09.727632",
+     "start_time": "2021-12-02T04:34:20.548041",
      "status": "completed"
     },
     "tags": []
@@ -357,10 +357,10 @@
    "id": "13ba811b",
    "metadata": {
     "papermill": {
-     "duration": 0.092051,
-     "end_time": "2021-11-28T04:46:10.004453",
+     "duration": 0.092926,
+     "end_time": "2021-12-02T04:34:20.826776",
      "exception": false,
-     "start_time": "2021-11-28T04:46:09.912402",
+     "start_time": "2021-12-02T04:34:20.733850",
      "status": "completed"
     },
     "tags": []
@@ -375,16 +375,16 @@
    "id": "68064f0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:10.193236Z",
-     "iopub.status.busy": "2021-11-28T04:46:10.192775Z",
-     "iopub.status.idle": "2021-11-28T04:46:10.194188Z",
-     "shell.execute_reply": "2021-11-28T04:46:10.194541Z"
+     "iopub.execute_input": "2021-12-02T04:34:21.026855Z",
+     "iopub.status.busy": "2021-12-02T04:34:21.026243Z",
+     "iopub.status.idle": "2021-12-02T04:34:21.028562Z",
+     "shell.execute_reply": "2021-12-02T04:34:21.027971Z"
     },
     "papermill": {
-     "duration": 0.097626,
-     "end_time": "2021-11-28T04:46:10.194658",
+     "duration": 0.107158,
+     "end_time": "2021-12-02T04:34:21.028689",
      "exception": false,
-     "start_time": "2021-11-28T04:46:10.097032",
+     "start_time": "2021-12-02T04:34:20.921531",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +400,16 @@
    "id": "6f2ff213-d6b7-458f-acbf-8c73dd497a2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:10.383715Z",
-     "iopub.status.busy": "2021-11-28T04:46:10.383269Z",
-     "iopub.status.idle": "2021-11-28T04:46:10.385603Z",
-     "shell.execute_reply": "2021-11-28T04:46:10.385161Z"
+     "iopub.execute_input": "2021-12-02T04:34:21.225799Z",
+     "iopub.status.busy": "2021-12-02T04:34:21.225350Z",
+     "iopub.status.idle": "2021-12-02T04:34:21.226800Z",
+     "shell.execute_reply": "2021-12-02T04:34:21.227141Z"
     },
     "papermill": {
-     "duration": 0.097741,
-     "end_time": "2021-11-28T04:46:10.385698",
+     "duration": 0.09836,
+     "end_time": "2021-12-02T04:34:21.227254",
      "exception": false,
-     "start_time": "2021-11-28T04:46:10.287957",
+     "start_time": "2021-12-02T04:34:21.128894",
      "status": "completed"
     },
     "tags": []
@@ -426,16 +426,16 @@
    "id": "d63012be-4fc7-4fba-bccd-ad155905d1d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:10.582395Z",
-     "iopub.status.busy": "2021-11-28T04:46:10.581923Z",
-     "iopub.status.idle": "2021-11-28T04:46:10.583382Z",
-     "shell.execute_reply": "2021-11-28T04:46:10.583733Z"
+     "iopub.execute_input": "2021-12-02T04:34:21.418916Z",
+     "iopub.status.busy": "2021-12-02T04:34:21.418477Z",
+     "iopub.status.idle": "2021-12-02T04:34:21.420269Z",
+     "shell.execute_reply": "2021-12-02T04:34:21.420631Z"
     },
     "papermill": {
-     "duration": 0.103718,
-     "end_time": "2021-11-28T04:46:10.583922",
+     "duration": 0.098786,
+     "end_time": "2021-12-02T04:34:21.420745",
      "exception": false,
-     "start_time": "2021-11-28T04:46:10.480204",
+     "start_time": "2021-12-02T04:34:21.321959",
      "status": "completed"
     },
     "tags": []
@@ -453,16 +453,16 @@
    "id": "c0abc65a-2f3c-4476-9c2a-f8d7753b75e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:10.772272Z",
-     "iopub.status.busy": "2021-11-28T04:46:10.769767Z",
-     "iopub.status.idle": "2021-11-28T04:46:23.704555Z",
-     "shell.execute_reply": "2021-11-28T04:46:23.704958Z"
+     "iopub.execute_input": "2021-12-02T04:34:21.614745Z",
+     "iopub.status.busy": "2021-12-02T04:34:21.614223Z",
+     "iopub.status.idle": "2021-12-02T04:34:33.925655Z",
+     "shell.execute_reply": "2021-12-02T04:34:33.925209Z"
     },
     "papermill": {
-     "duration": 13.028688,
-     "end_time": "2021-11-28T04:46:23.705083",
+     "duration": 12.410211,
+     "end_time": "2021-12-02T04:34:33.925764",
      "exception": false,
-     "start_time": "2021-11-28T04:46:10.676395",
+     "start_time": "2021-12-02T04:34:21.515553",
      "status": "completed"
     },
     "tags": []
@@ -472,7 +472,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15.7 ms ± 411 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "15.1 ms ± 1.13 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -487,16 +487,16 @@
    "id": "e80a7b02-310f-4bd9-90d5-2a41186db39e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:23.897759Z",
-     "iopub.status.busy": "2021-11-28T04:46:23.895192Z",
-     "iopub.status.idle": "2021-11-28T04:46:23.920734Z",
-     "shell.execute_reply": "2021-11-28T04:46:23.921126Z"
+     "iopub.execute_input": "2021-12-02T04:34:34.125850Z",
+     "iopub.status.busy": "2021-12-02T04:34:34.125263Z",
+     "iopub.status.idle": "2021-12-02T04:34:34.148529Z",
+     "shell.execute_reply": "2021-12-02T04:34:34.148886Z"
     },
     "papermill": {
-     "duration": 0.120849,
-     "end_time": "2021-11-28T04:46:23.921249",
+     "duration": 0.124845,
+     "end_time": "2021-12-02T04:34:34.149006",
      "exception": false,
-     "start_time": "2021-11-28T04:46:23.800400",
+     "start_time": "2021-12-02T04:34:34.024161",
      "status": "completed"
     },
     "tags": []
@@ -521,10 +521,10 @@
    "id": "2548440c",
    "metadata": {
     "papermill": {
-     "duration": 0.092771,
-     "end_time": "2021-11-28T04:46:24.109881",
+     "duration": 0.094866,
+     "end_time": "2021-12-02T04:34:34.338010",
      "exception": false,
-     "start_time": "2021-11-28T04:46:24.017110",
+     "start_time": "2021-12-02T04:34:34.243144",
      "status": "completed"
     },
     "tags": []
@@ -539,16 +539,16 @@
    "id": "ddb768d7-9b74-424c-bdb9-9e52b9e5b181",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:24.300032Z",
-     "iopub.status.busy": "2021-11-28T04:46:24.299522Z",
-     "iopub.status.idle": "2021-11-28T04:46:24.301101Z",
-     "shell.execute_reply": "2021-11-28T04:46:24.301439Z"
+     "iopub.execute_input": "2021-12-02T04:34:34.530550Z",
+     "iopub.status.busy": "2021-12-02T04:34:34.530085Z",
+     "iopub.status.idle": "2021-12-02T04:34:34.531559Z",
+     "shell.execute_reply": "2021-12-02T04:34:34.531910Z"
     },
     "papermill": {
-     "duration": 0.098495,
-     "end_time": "2021-11-28T04:46:24.301553",
+     "duration": 0.099465,
+     "end_time": "2021-12-02T04:34:34.532025",
      "exception": false,
-     "start_time": "2021-11-28T04:46:24.203058",
+     "start_time": "2021-12-02T04:34:34.432560",
      "status": "completed"
     },
     "tags": []
@@ -564,16 +564,16 @@
    "id": "161cf922-41f7-4ced-af1f-e3d25b36b200",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:24.491958Z",
-     "iopub.status.busy": "2021-11-28T04:46:24.491459Z",
-     "iopub.status.idle": "2021-11-28T04:46:24.493117Z",
-     "shell.execute_reply": "2021-11-28T04:46:24.493478Z"
+     "iopub.execute_input": "2021-12-02T04:34:34.723894Z",
+     "iopub.status.busy": "2021-12-02T04:34:34.723405Z",
+     "iopub.status.idle": "2021-12-02T04:34:34.725017Z",
+     "shell.execute_reply": "2021-12-02T04:34:34.725362Z"
     },
     "papermill": {
-     "duration": 0.098071,
-     "end_time": "2021-11-28T04:46:24.493590",
+     "duration": 0.099541,
+     "end_time": "2021-12-02T04:34:34.725479",
      "exception": false,
-     "start_time": "2021-11-28T04:46:24.395519",
+     "start_time": "2021-12-02T04:34:34.625938",
      "status": "completed"
     },
     "tags": []
@@ -590,16 +590,16 @@
    "id": "ede7a328-bad3-40a2-a179-1148a3229620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:24.691045Z",
-     "iopub.status.busy": "2021-11-28T04:46:24.690590Z",
-     "iopub.status.idle": "2021-11-28T04:46:24.692049Z",
-     "shell.execute_reply": "2021-11-28T04:46:24.692389Z"
+     "iopub.execute_input": "2021-12-02T04:34:34.917755Z",
+     "iopub.status.busy": "2021-12-02T04:34:34.917311Z",
+     "iopub.status.idle": "2021-12-02T04:34:34.919529Z",
+     "shell.execute_reply": "2021-12-02T04:34:34.919083Z"
     },
     "papermill": {
-     "duration": 0.098815,
-     "end_time": "2021-11-28T04:46:24.692505",
+     "duration": 0.099235,
+     "end_time": "2021-12-02T04:34:34.919621",
      "exception": false,
-     "start_time": "2021-11-28T04:46:24.593690",
+     "start_time": "2021-12-02T04:34:34.820386",
      "status": "completed"
     },
     "tags": []
@@ -617,16 +617,16 @@
    "id": "0a7f2b1f-4b87-4dde-a46b-2acec5ac93ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:24.884953Z",
-     "iopub.status.busy": "2021-11-28T04:46:24.884266Z",
-     "iopub.status.idle": "2021-11-28T04:46:27.857232Z",
-     "shell.execute_reply": "2021-11-28T04:46:27.856743Z"
+     "iopub.execute_input": "2021-12-02T04:34:35.120950Z",
+     "iopub.status.busy": "2021-12-02T04:34:35.120480Z",
+     "iopub.status.idle": "2021-12-02T04:34:37.984893Z",
+     "shell.execute_reply": "2021-12-02T04:34:37.985354Z"
     },
     "papermill": {
-     "duration": 3.07086,
-     "end_time": "2021-11-28T04:46:27.857349",
+     "duration": 2.971389,
+     "end_time": "2021-12-02T04:34:37.985494",
      "exception": false,
-     "start_time": "2021-11-28T04:46:24.786489",
+     "start_time": "2021-12-02T04:34:35.014105",
      "status": "completed"
     },
     "tags": []
@@ -636,7 +636,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "34 ms ± 1.84 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "32.5 ms ± 2.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -651,16 +651,16 @@
    "id": "74acbe27-9807-4f26-8b7e-b74d0f745b63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:28.056758Z",
-     "iopub.status.busy": "2021-11-28T04:46:28.055945Z",
-     "iopub.status.idle": "2021-11-28T04:46:28.092549Z",
-     "shell.execute_reply": "2021-11-28T04:46:28.092917Z"
+     "iopub.execute_input": "2021-12-02T04:34:38.190471Z",
+     "iopub.status.busy": "2021-12-02T04:34:38.189361Z",
+     "iopub.status.idle": "2021-12-02T04:34:38.227298Z",
+     "shell.execute_reply": "2021-12-02T04:34:38.227692Z"
     },
     "papermill": {
-     "duration": 0.136369,
-     "end_time": "2021-11-28T04:46:28.093042",
+     "duration": 0.13744,
+     "end_time": "2021-12-02T04:34:38.227812",
      "exception": false,
-     "start_time": "2021-11-28T04:46:27.956673",
+     "start_time": "2021-12-02T04:34:38.090372",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "611ff8e1",
    "metadata": {
     "papermill": {
-     "duration": 0.09522,
-     "end_time": "2021-11-28T04:46:28.284135",
+     "duration": 0.09562,
+     "end_time": "2021-12-02T04:34:38.420643",
      "exception": false,
-     "start_time": "2021-11-28T04:46:28.188915",
+     "start_time": "2021-12-02T04:34:38.325023",
      "status": "completed"
     },
     "tags": []
@@ -703,16 +703,16 @@
    "id": "4bcf4b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:28.476660Z",
-     "iopub.status.busy": "2021-11-28T04:46:28.476196Z",
-     "iopub.status.idle": "2021-11-28T04:46:28.477727Z",
-     "shell.execute_reply": "2021-11-28T04:46:28.478086Z"
+     "iopub.execute_input": "2021-12-02T04:34:38.617318Z",
+     "iopub.status.busy": "2021-12-02T04:34:38.616836Z",
+     "iopub.status.idle": "2021-12-02T04:34:38.618469Z",
+     "shell.execute_reply": "2021-12-02T04:34:38.618817Z"
     },
     "papermill": {
-     "duration": 0.099102,
-     "end_time": "2021-11-28T04:46:28.478199",
+     "duration": 0.101998,
+     "end_time": "2021-12-02T04:34:38.618933",
      "exception": false,
-     "start_time": "2021-11-28T04:46:28.379097",
+     "start_time": "2021-12-02T04:34:38.516935",
      "status": "completed"
     },
     "tags": []
@@ -728,16 +728,16 @@
    "id": "0bf2f21e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:28.678244Z",
-     "iopub.status.busy": "2021-11-28T04:46:28.677795Z",
-     "iopub.status.idle": "2021-11-28T04:46:28.679405Z",
-     "shell.execute_reply": "2021-11-28T04:46:28.679744Z"
+     "iopub.execute_input": "2021-12-02T04:34:38.813589Z",
+     "iopub.status.busy": "2021-12-02T04:34:38.813117Z",
+     "iopub.status.idle": "2021-12-02T04:34:38.815386Z",
+     "shell.execute_reply": "2021-12-02T04:34:38.815020Z"
     },
     "papermill": {
-     "duration": 0.100673,
-     "end_time": "2021-11-28T04:46:28.679860",
+     "duration": 0.100616,
+     "end_time": "2021-12-02T04:34:38.815484",
      "exception": false,
-     "start_time": "2021-11-28T04:46:28.579187",
+     "start_time": "2021-12-02T04:34:38.714868",
      "status": "completed"
     },
     "tags": []
@@ -754,16 +754,16 @@
    "id": "24c352bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:28.874625Z",
-     "iopub.status.busy": "2021-11-28T04:46:28.874139Z",
-     "iopub.status.idle": "2021-11-28T04:46:28.876361Z",
-     "shell.execute_reply": "2021-11-28T04:46:28.875926Z"
+     "iopub.execute_input": "2021-12-02T04:34:39.010047Z",
+     "iopub.status.busy": "2021-12-02T04:34:39.009506Z",
+     "iopub.status.idle": "2021-12-02T04:34:39.011025Z",
+     "shell.execute_reply": "2021-12-02T04:34:39.011367Z"
     },
     "papermill": {
-     "duration": 0.100659,
-     "end_time": "2021-11-28T04:46:28.876498",
+     "duration": 0.100056,
+     "end_time": "2021-12-02T04:34:39.011481",
      "exception": false,
-     "start_time": "2021-11-28T04:46:28.775839",
+     "start_time": "2021-12-02T04:34:38.911425",
      "status": "completed"
     },
     "tags": []
@@ -781,16 +781,16 @@
    "id": "cbde4ce6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:29.070683Z",
-     "iopub.status.busy": "2021-11-28T04:46:29.070200Z",
-     "iopub.status.idle": "2021-11-28T04:46:33.134294Z",
-     "shell.execute_reply": "2021-11-28T04:46:33.133834Z"
+     "iopub.execute_input": "2021-12-02T04:34:39.216775Z",
+     "iopub.status.busy": "2021-12-02T04:34:39.216014Z",
+     "iopub.status.idle": "2021-12-02T04:34:43.223179Z",
+     "shell.execute_reply": "2021-12-02T04:34:43.223640Z"
     },
     "papermill": {
-     "duration": 4.163583,
-     "end_time": "2021-11-28T04:46:33.134414",
+     "duration": 4.108094,
+     "end_time": "2021-12-02T04:34:43.223780",
      "exception": false,
-     "start_time": "2021-11-28T04:46:28.970831",
+     "start_time": "2021-12-02T04:34:39.115686",
      "status": "completed"
     },
     "tags": []
@@ -800,7 +800,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "46.1 ms ± 619 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "45.8 ms ± 2.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -815,16 +815,16 @@
    "id": "1250547e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:33.335390Z",
-     "iopub.status.busy": "2021-11-28T04:46:33.334886Z",
-     "iopub.status.idle": "2021-11-28T04:46:33.383444Z",
-     "shell.execute_reply": "2021-11-28T04:46:33.383047Z"
+     "iopub.execute_input": "2021-12-02T04:34:43.427169Z",
+     "iopub.status.busy": "2021-12-02T04:34:43.426487Z",
+     "iopub.status.idle": "2021-12-02T04:34:43.474288Z",
+     "shell.execute_reply": "2021-12-02T04:34:43.473832Z"
     },
     "papermill": {
-     "duration": 0.148948,
-     "end_time": "2021-11-28T04:46:33.383542",
+     "duration": 0.148908,
+     "end_time": "2021-12-02T04:34:43.474385",
      "exception": false,
-     "start_time": "2021-11-28T04:46:33.234594",
+     "start_time": "2021-12-02T04:34:43.325477",
      "status": "completed"
     },
     "tags": []
@@ -849,10 +849,10 @@
    "id": "6853c300",
    "metadata": {
     "papermill": {
-     "duration": 0.099121,
-     "end_time": "2021-11-28T04:46:33.580451",
+     "duration": 0.09707,
+     "end_time": "2021-12-02T04:34:43.669776",
      "exception": false,
-     "start_time": "2021-11-28T04:46:33.481330",
+     "start_time": "2021-12-02T04:34:43.572706",
      "status": "completed"
     },
     "tags": []
@@ -867,16 +867,16 @@
    "id": "f77e8490",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:33.814006Z",
-     "iopub.status.busy": "2021-11-28T04:46:33.813554Z",
-     "iopub.status.idle": "2021-11-28T04:46:33.815010Z",
-     "shell.execute_reply": "2021-11-28T04:46:33.815371Z"
+     "iopub.execute_input": "2021-12-02T04:34:43.871037Z",
+     "iopub.status.busy": "2021-12-02T04:34:43.870573Z",
+     "iopub.status.idle": "2021-12-02T04:34:43.872099Z",
+     "shell.execute_reply": "2021-12-02T04:34:43.872442Z"
     },
     "papermill": {
-     "duration": 0.108775,
-     "end_time": "2021-11-28T04:46:33.815486",
+     "duration": 0.103066,
+     "end_time": "2021-12-02T04:34:43.872558",
      "exception": false,
-     "start_time": "2021-11-28T04:46:33.706711",
+     "start_time": "2021-12-02T04:34:43.769492",
      "status": "completed"
     },
     "tags": []
@@ -892,16 +892,16 @@
    "id": "c99f544a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:34.013901Z",
-     "iopub.status.busy": "2021-11-28T04:46:34.013450Z",
-     "iopub.status.idle": "2021-11-28T04:46:34.015667Z",
-     "shell.execute_reply": "2021-11-28T04:46:34.015231Z"
+     "iopub.execute_input": "2021-12-02T04:34:44.102128Z",
+     "iopub.status.busy": "2021-12-02T04:34:44.101540Z",
+     "iopub.status.idle": "2021-12-02T04:34:44.103376Z",
+     "shell.execute_reply": "2021-12-02T04:34:44.103817Z"
     },
     "papermill": {
-     "duration": 0.101722,
-     "end_time": "2021-11-28T04:46:34.015761",
+     "duration": 0.13265,
+     "end_time": "2021-12-02T04:34:44.103967",
      "exception": false,
-     "start_time": "2021-11-28T04:46:33.914039",
+     "start_time": "2021-12-02T04:34:43.971317",
      "status": "completed"
     },
     "tags": []
@@ -918,16 +918,16 @@
    "id": "d907f1d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:34.212681Z",
-     "iopub.status.busy": "2021-11-28T04:46:34.212178Z",
-     "iopub.status.idle": "2021-11-28T04:46:34.213777Z",
-     "shell.execute_reply": "2021-11-28T04:46:34.214139Z"
+     "iopub.execute_input": "2021-12-02T04:34:44.311356Z",
+     "iopub.status.busy": "2021-12-02T04:34:44.310862Z",
+     "iopub.status.idle": "2021-12-02T04:34:44.313206Z",
+     "shell.execute_reply": "2021-12-02T04:34:44.312818Z"
     },
     "papermill": {
-     "duration": 0.101827,
-     "end_time": "2021-11-28T04:46:34.214253",
+     "duration": 0.103411,
+     "end_time": "2021-12-02T04:34:44.313301",
      "exception": false,
-     "start_time": "2021-11-28T04:46:34.112426",
+     "start_time": "2021-12-02T04:34:44.209890",
      "status": "completed"
     },
     "tags": []
@@ -945,16 +945,16 @@
    "id": "9721b048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:34.415600Z",
-     "iopub.status.busy": "2021-11-28T04:46:34.415125Z",
-     "iopub.status.idle": "2021-11-28T04:46:40.594002Z",
-     "shell.execute_reply": "2021-11-28T04:46:40.593320Z"
+     "iopub.execute_input": "2021-12-02T04:34:44.515965Z",
+     "iopub.status.busy": "2021-12-02T04:34:44.515462Z",
+     "iopub.status.idle": "2021-12-02T04:34:50.907897Z",
+     "shell.execute_reply": "2021-12-02T04:34:50.908362Z"
     },
     "papermill": {
-     "duration": 6.28115,
-     "end_time": "2021-11-28T04:46:40.594131",
+     "duration": 6.496377,
+     "end_time": "2021-12-02T04:34:50.908503",
      "exception": false,
-     "start_time": "2021-11-28T04:46:34.312981",
+     "start_time": "2021-12-02T04:34:44.412126",
      "status": "completed"
     },
     "tags": []
@@ -964,7 +964,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "70.3 ms ± 2.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "72.3 ms ± 931 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -979,16 +979,16 @@
    "id": "fd0f4dd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:40.808350Z",
-     "iopub.status.busy": "2021-11-28T04:46:40.807860Z",
-     "iopub.status.idle": "2021-11-28T04:46:40.879913Z",
-     "shell.execute_reply": "2021-11-28T04:46:40.879499Z"
+     "iopub.execute_input": "2021-12-02T04:34:51.122723Z",
+     "iopub.status.busy": "2021-12-02T04:34:51.122244Z",
+     "iopub.status.idle": "2021-12-02T04:34:51.194219Z",
+     "shell.execute_reply": "2021-12-02T04:34:51.193813Z"
     },
     "papermill": {
-     "duration": 0.175847,
-     "end_time": "2021-11-28T04:46:40.880015",
+     "duration": 0.179898,
+     "end_time": "2021-12-02T04:34:51.194319",
      "exception": false,
-     "start_time": "2021-11-28T04:46:40.704168",
+     "start_time": "2021-12-02T04:34:51.014421",
      "status": "completed"
     },
     "tags": []
@@ -1013,10 +1013,10 @@
    "id": "f6b9adcf-1da4-4496-b05f-47952fd80d7f",
    "metadata": {
     "papermill": {
-     "duration": 0.098717,
-     "end_time": "2021-11-28T04:46:41.077266",
+     "duration": 0.099861,
+     "end_time": "2021-12-02T04:34:51.394504",
      "exception": false,
-     "start_time": "2021-11-28T04:46:40.978549",
+     "start_time": "2021-12-02T04:34:51.294643",
      "status": "completed"
     },
     "tags": []
@@ -1030,10 +1030,10 @@
    "id": "8f2e407c",
    "metadata": {
     "papermill": {
-     "duration": 0.098604,
-     "end_time": "2021-11-28T04:46:41.274893",
+     "duration": 0.098767,
+     "end_time": "2021-12-02T04:34:51.593072",
      "exception": false,
-     "start_time": "2021-11-28T04:46:41.176289",
+     "start_time": "2021-12-02T04:34:51.494305",
      "status": "completed"
     },
     "tags": []
@@ -1048,16 +1048,16 @@
    "id": "c522396e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:41.475226Z",
-     "iopub.status.busy": "2021-11-28T04:46:41.474760Z",
-     "iopub.status.idle": "2021-11-28T04:46:41.476404Z",
-     "shell.execute_reply": "2021-11-28T04:46:41.476747Z"
+     "iopub.execute_input": "2021-12-02T04:34:51.793258Z",
+     "iopub.status.busy": "2021-12-02T04:34:51.792385Z",
+     "iopub.status.idle": "2021-12-02T04:34:51.794710Z",
+     "shell.execute_reply": "2021-12-02T04:34:51.795054Z"
     },
     "papermill": {
-     "duration": 0.103194,
-     "end_time": "2021-11-28T04:46:41.476863",
+     "duration": 0.103749,
+     "end_time": "2021-12-02T04:34:51.795172",
      "exception": false,
-     "start_time": "2021-11-28T04:46:41.373669",
+     "start_time": "2021-12-02T04:34:51.691423",
      "status": "completed"
     },
     "tags": []
@@ -1073,16 +1073,16 @@
    "id": "a5e536cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:41.682386Z",
-     "iopub.status.busy": "2021-11-28T04:46:41.681856Z",
-     "iopub.status.idle": "2021-11-28T04:46:41.685232Z",
-     "shell.execute_reply": "2021-11-28T04:46:41.684774Z"
+     "iopub.execute_input": "2021-12-02T04:34:51.996666Z",
+     "iopub.status.busy": "2021-12-02T04:34:51.996120Z",
+     "iopub.status.idle": "2021-12-02T04:34:51.999329Z",
+     "shell.execute_reply": "2021-12-02T04:34:51.998896Z"
     },
     "papermill": {
-     "duration": 0.11061,
-     "end_time": "2021-11-28T04:46:41.685326",
+     "duration": 0.104554,
+     "end_time": "2021-12-02T04:34:51.999423",
      "exception": false,
-     "start_time": "2021-11-28T04:46:41.574716",
+     "start_time": "2021-12-02T04:34:51.894869",
      "status": "completed"
     },
     "tags": []
@@ -1099,16 +1099,16 @@
    "id": "15cb532e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:41.885998Z",
-     "iopub.status.busy": "2021-11-28T04:46:41.884776Z",
-     "iopub.status.idle": "2021-11-28T04:46:41.888217Z",
-     "shell.execute_reply": "2021-11-28T04:46:41.887723Z"
+     "iopub.execute_input": "2021-12-02T04:34:52.206165Z",
+     "iopub.status.busy": "2021-12-02T04:34:52.205716Z",
+     "iopub.status.idle": "2021-12-02T04:34:52.207991Z",
+     "shell.execute_reply": "2021-12-02T04:34:52.207535Z"
     },
     "papermill": {
-     "duration": 0.104745,
-     "end_time": "2021-11-28T04:46:41.888309",
+     "duration": 0.10765,
+     "end_time": "2021-12-02T04:34:52.208087",
      "exception": false,
-     "start_time": "2021-11-28T04:46:41.783564",
+     "start_time": "2021-12-02T04:34:52.100437",
      "status": "completed"
     },
     "tags": []
@@ -1126,16 +1126,16 @@
    "id": "91470f64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:46:42.088928Z",
-     "iopub.status.busy": "2021-11-28T04:46:42.088313Z",
-     "iopub.status.idle": "2021-11-28T04:47:17.565897Z",
-     "shell.execute_reply": "2021-11-28T04:47:17.566246Z"
+     "iopub.execute_input": "2021-12-02T04:34:52.408864Z",
+     "iopub.status.busy": "2021-12-02T04:34:52.408310Z",
+     "iopub.status.idle": "2021-12-02T04:35:28.383597Z",
+     "shell.execute_reply": "2021-12-02T04:35:28.384010Z"
     },
     "papermill": {
-     "duration": 35.579865,
-     "end_time": "2021-11-28T04:47:17.566356",
+     "duration": 36.078113,
+     "end_time": "2021-12-02T04:35:28.384125",
      "exception": false,
-     "start_time": "2021-11-28T04:46:41.986491",
+     "start_time": "2021-12-02T04:34:52.306012",
      "status": "completed"
     },
     "tags": []
@@ -1145,7 +1145,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.21 s ± 6.46 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.24 s ± 7.94 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1160,16 +1160,16 @@
    "id": "4de4e0b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:47:17.771734Z",
-     "iopub.status.busy": "2021-11-28T04:47:17.771164Z",
-     "iopub.status.idle": "2021-11-28T04:47:19.992492Z",
-     "shell.execute_reply": "2021-11-28T04:47:19.992879Z"
+     "iopub.execute_input": "2021-12-02T04:35:28.594907Z",
+     "iopub.status.busy": "2021-12-02T04:35:28.594395Z",
+     "iopub.status.idle": "2021-12-02T04:35:30.850079Z",
+     "shell.execute_reply": "2021-12-02T04:35:30.850466Z"
     },
     "papermill": {
-     "duration": 2.328959,
-     "end_time": "2021-11-28T04:47:19.992998",
+     "duration": 2.36055,
+     "end_time": "2021-12-02T04:35:30.850581",
      "exception": false,
-     "start_time": "2021-11-28T04:47:17.664039",
+     "start_time": "2021-12-02T04:35:28.490031",
      "status": "completed"
     },
     "tags": []
@@ -1194,10 +1194,10 @@
    "id": "b0c07894",
    "metadata": {
     "papermill": {
-     "duration": 0.099916,
-     "end_time": "2021-11-28T04:47:20.196769",
+     "duration": 0.100749,
+     "end_time": "2021-12-02T04:35:31.053465",
      "exception": false,
-     "start_time": "2021-11-28T04:47:20.096853",
+     "start_time": "2021-12-02T04:35:30.952716",
      "status": "completed"
     },
     "tags": []
@@ -1212,16 +1212,16 @@
    "id": "7fb2ab2e-a6de-412b-9540-d00f8641290e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:47:20.399312Z",
-     "iopub.status.busy": "2021-11-28T04:47:20.398862Z",
-     "iopub.status.idle": "2021-11-28T04:47:20.400352Z",
-     "shell.execute_reply": "2021-11-28T04:47:20.400713Z"
+     "iopub.execute_input": "2021-12-02T04:35:31.262806Z",
+     "iopub.status.busy": "2021-12-02T04:35:31.262280Z",
+     "iopub.status.idle": "2021-12-02T04:35:31.264634Z",
+     "shell.execute_reply": "2021-12-02T04:35:31.264124Z"
     },
     "papermill": {
-     "duration": 0.105136,
-     "end_time": "2021-11-28T04:47:20.400828",
+     "duration": 0.110468,
+     "end_time": "2021-12-02T04:35:31.264738",
      "exception": false,
-     "start_time": "2021-11-28T04:47:20.295692",
+     "start_time": "2021-12-02T04:35:31.154270",
      "status": "completed"
     },
     "tags": []
@@ -1237,16 +1237,16 @@
    "id": "81765e91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:47:20.603728Z",
-     "iopub.status.busy": "2021-11-28T04:47:20.603244Z",
-     "iopub.status.idle": "2021-11-28T04:47:20.606349Z",
-     "shell.execute_reply": "2021-11-28T04:47:20.606703Z"
+     "iopub.execute_input": "2021-12-02T04:35:31.472530Z",
+     "iopub.status.busy": "2021-12-02T04:35:31.472083Z",
+     "iopub.status.idle": "2021-12-02T04:35:31.475862Z",
+     "shell.execute_reply": "2021-12-02T04:35:31.475424Z"
     },
     "papermill": {
-     "duration": 0.105674,
-     "end_time": "2021-11-28T04:47:20.606816",
+     "duration": 0.107444,
+     "end_time": "2021-12-02T04:35:31.476016",
      "exception": false,
-     "start_time": "2021-11-28T04:47:20.501142",
+     "start_time": "2021-12-02T04:35:31.368572",
      "status": "completed"
     },
     "tags": []
@@ -1263,16 +1263,16 @@
    "id": "d408b318",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:47:20.815436Z",
-     "iopub.status.busy": "2021-11-28T04:47:20.813869Z",
-     "iopub.status.idle": "2021-11-28T04:47:20.817810Z",
-     "shell.execute_reply": "2021-11-28T04:47:20.817367Z"
+     "iopub.execute_input": "2021-12-02T04:35:31.682735Z",
+     "iopub.status.busy": "2021-12-02T04:35:31.682239Z",
+     "iopub.status.idle": "2021-12-02T04:35:31.684357Z",
+     "shell.execute_reply": "2021-12-02T04:35:31.683794Z"
     },
     "papermill": {
-     "duration": 0.111317,
-     "end_time": "2021-11-28T04:47:20.817905",
+     "duration": 0.10675,
+     "end_time": "2021-12-02T04:35:31.684477",
      "exception": false,
-     "start_time": "2021-11-28T04:47:20.706588",
+     "start_time": "2021-12-02T04:35:31.577727",
      "status": "completed"
     },
     "tags": []
@@ -1290,16 +1290,16 @@
    "id": "aca57100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:47:21.020323Z",
-     "iopub.status.busy": "2021-11-28T04:47:21.019673Z",
-     "iopub.status.idle": "2021-11-28T04:48:34.665604Z",
-     "shell.execute_reply": "2021-11-28T04:48:34.665957Z"
+     "iopub.execute_input": "2021-12-02T04:35:31.892045Z",
+     "iopub.status.busy": "2021-12-02T04:35:31.891417Z",
+     "iopub.status.idle": "2021-12-02T04:36:46.681345Z",
+     "shell.execute_reply": "2021-12-02T04:36:46.681695Z"
     },
     "papermill": {
-     "duration": 73.74829,
-     "end_time": "2021-11-28T04:48:34.666067",
+     "duration": 74.896315,
+     "end_time": "2021-12-02T04:36:46.681806",
      "exception": false,
-     "start_time": "2021-11-28T04:47:20.917777",
+     "start_time": "2021-12-02T04:35:31.785491",
      "status": "completed"
     },
     "tags": []
@@ -1309,7 +1309,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.6 s ± 3.87 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "4.67 s ± 6.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1324,16 +1324,16 @@
    "id": "b9c25f30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:34.868305Z",
-     "iopub.status.busy": "2021-11-28T04:48:34.867610Z",
-     "iopub.status.idle": "2021-11-28T04:48:39.475938Z",
-     "shell.execute_reply": "2021-11-28T04:48:39.475453Z"
+     "iopub.execute_input": "2021-12-02T04:36:46.889124Z",
+     "iopub.status.busy": "2021-12-02T04:36:46.888441Z",
+     "iopub.status.idle": "2021-12-02T04:36:51.544747Z",
+     "shell.execute_reply": "2021-12-02T04:36:51.544315Z"
     },
     "papermill": {
-     "duration": 4.711131,
-     "end_time": "2021-11-28T04:48:39.476033",
+     "duration": 4.761869,
+     "end_time": "2021-12-02T04:36:51.544839",
      "exception": false,
-     "start_time": "2021-11-28T04:48:34.764902",
+     "start_time": "2021-12-02T04:36:46.782970",
      "status": "completed"
     },
     "tags": []
@@ -1359,10 +1359,10 @@
    "id": "2aa76596-f126-4ba8-8bba-4d31225e0e5d",
    "metadata": {
     "papermill": {
-     "duration": 0.100404,
-     "end_time": "2021-11-28T04:48:39.677864",
+     "duration": 0.102208,
+     "end_time": "2021-12-02T04:36:51.764154",
      "exception": false,
-     "start_time": "2021-11-28T04:48:39.577460",
+     "start_time": "2021-12-02T04:36:51.661946",
      "status": "completed"
     },
     "tags": []
@@ -1394,14 +1394,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 165.910218,
-   "end_time": "2021-11-28T04:48:40.187191",
+   "duration": 167.355469,
+   "end_time": "2021-12-02T04:36:52.275357",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/10_cm_optimized/09-cdist_parts_v04.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/10_cm_optimized/09-cdist_parts_v04.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T04:45:54.276973",
+   "start_time": "2021-12-02T04:34:04.919888",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_large_100000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_large_100000.txt
@@ -1,26 +1,26 @@
-         9636 function calls in 4.604 seconds
+         9634 function calls in 4.652 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    4.604    4.604 {built-in method builtins.exec}
-        1    0.000    0.000    4.604    4.604 <string>:1(<module>)
-        1    0.000    0.000    4.604    4.604 1517976664.py:1(func)
-       10    0.005    0.000    4.604    0.460 coef.py:252(cm)
-      892    4.578    0.005    4.578    0.005 {method 'acquire' of '_thread.lock' objects}
-      221    0.001    0.000    4.578    0.021 threading.py:280(wait)
-       10    0.001    0.000    3.123    0.312 coef.py:387(compute_coef)
-       10    0.000    0.000    3.122    0.312 coef.py:380(cdist_func)
-       10    0.001    0.000    3.122    0.312 coef.py:168(cdist_parts_parallel)
-      120    0.000    0.000    3.113    0.026 threading.py:556(wait)
-      100    0.001    0.000    3.113    0.031 _base.py:201(as_completed)
-      110    0.000    0.000    1.465    0.013 _base.py:417(result)
-       30    0.000    0.000    1.465    0.049 _base.py:601(result_iterator)
+        1    0.000    0.000    4.652    4.652 {built-in method builtins.exec}
+        1    0.000    0.000    4.652    4.652 <string>:1(<module>)
+        1    0.000    0.000    4.652    4.652 1517976664.py:1(func)
+       10    0.005    0.001    4.652    0.465 coef.py:275(cm)
+      221    0.001    0.000    4.626    0.021 threading.py:280(wait)
+      892    4.626    0.005    4.626    0.005 {method 'acquire' of '_thread.lock' objects}
+       10    0.001    0.000    3.121    0.312 coef.py:414(compute_coef)
+       10    0.000    0.000    3.120    0.312 coef.py:407(cdist_func)
+       10    0.001    0.000    3.119    0.312 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    3.110    0.026 threading.py:556(wait)
+      100    0.001    0.000    3.110    0.031 _base.py:201(as_completed)
+      110    0.000    0.000    1.516    0.014 _base.py:417(result)
+       30    0.000    0.000    1.516    0.051 _base.py:601(result_iterator)
+       10    0.004    0.000    0.008    0.001 coef.py:186(<dictcomp>)
       110    0.001    0.000    0.008    0.000 thread.py:155(submit)
-       10    0.004    0.000    0.008    0.001 coef.py:178(<dictcomp>)
-      110    0.001    0.000    0.006    0.000 thread.py:174(_adjust_thread_count)
+      110    0.000    0.000    0.006    0.000 thread.py:174(_adjust_thread_count)
        30    0.000    0.000    0.004    0.000 threading.py:873(start)
        10    0.000    0.000    0.004    0.000 _base.py:572(map)
        10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
-       10    0.000    0.000    0.003    0.000 _base.py:635(__exit__)
+       50    0.003    0.000    0.003    0.000 {built-in method numpy.zeros}

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_large_50000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_large_50000.txt
@@ -1,24 +1,24 @@
-         9629 function calls in 2.218 seconds
+         9632 function calls in 2.252 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    2.218    2.218 {built-in method builtins.exec}
-        1    0.000    0.000    2.218    2.218 <string>:1(<module>)
-        1    0.000    0.000    2.218    2.218 1517976664.py:1(func)
-       10    0.002    0.000    2.217    0.222 coef.py:252(cm)
-      890    2.197    0.002    2.197    0.002 {method 'acquire' of '_thread.lock' objects}
-      220    0.001    0.000    2.197    0.010 threading.py:280(wait)
-       10    0.001    0.000    1.535    0.153 coef.py:387(compute_coef)
-       10    0.000    0.000    1.534    0.153 coef.py:380(cdist_func)
-       10    0.001    0.000    1.534    0.153 coef.py:168(cdist_parts_parallel)
-      120    0.000    0.000    1.525    0.013 threading.py:556(wait)
-      100    0.001    0.000    1.524    0.015 _base.py:201(as_completed)
-      110    0.000    0.000    0.672    0.006 _base.py:417(result)
-       30    0.000    0.000    0.672    0.022 _base.py:601(result_iterator)
+        1    0.000    0.000    2.252    2.252 {built-in method builtins.exec}
+        1    0.000    0.000    2.252    2.252 <string>:1(<module>)
+        1    0.000    0.000    2.252    2.252 1517976664.py:1(func)
+       10    0.003    0.000    2.252    0.225 coef.py:275(cm)
+      890    2.231    0.003    2.231    0.003 {method 'acquire' of '_thread.lock' objects}
+      220    0.001    0.000    2.231    0.010 threading.py:280(wait)
+       10    0.001    0.000    1.547    0.155 coef.py:414(compute_coef)
+       10    0.000    0.000    1.546    0.155 coef.py:407(cdist_func)
+       10    0.001    0.000    1.546    0.155 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    1.538    0.013 threading.py:556(wait)
+      100    0.001    0.000    1.537    0.015 _base.py:201(as_completed)
+      110    0.000    0.000    0.693    0.006 _base.py:417(result)
+       30    0.000    0.000    0.693    0.023 _base.py:601(result_iterator)
       110    0.001    0.000    0.008    0.000 thread.py:155(submit)
-       10    0.003    0.000    0.008    0.001 coef.py:178(<dictcomp>)
+       10    0.002    0.000    0.007    0.001 coef.py:186(<dictcomp>)
       110    0.001    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
        30    0.000    0.000    0.004    0.000 threading.py:873(start)
        10    0.000    0.000    0.003    0.000 _base.py:572(map)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_100.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_100.txt
@@ -1,26 +1,26 @@
-         9030 function calls in 0.035 seconds
+         9212 function calls in 0.034 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.035    0.035 {built-in method builtins.exec}
-        1    0.000    0.000    0.035    0.035 <string>:1(<module>)
-        1    0.000    0.000    0.035    0.035 1517976664.py:1(func)
-       10    0.001    0.000    0.035    0.003 coef.py:252(cm)
-       10    0.000    0.000    0.028    0.003 coef.py:387(compute_coef)
-       10    0.000    0.000    0.027    0.003 coef.py:380(cdist_func)
+        1    0.000    0.000    0.034    0.034 {built-in method builtins.exec}
+        1    0.000    0.000    0.034    0.034 <string>:1(<module>)
+        1    0.000    0.000    0.034    0.034 1517976664.py:1(func)
+       10    0.001    0.000    0.034    0.003 coef.py:275(cm)
+       10    0.000    0.000    0.028    0.003 coef.py:414(compute_coef)
+       10    0.000    0.000    0.027    0.003 coef.py:407(cdist_func)
        10    0.003    0.000    0.027    0.003 coef.py:168(cdist_parts_parallel)
-      192    0.001    0.000    0.023    0.000 threading.py:280(wait)
-      770    0.022    0.000    0.022    0.000 {method 'acquire' of '_thread.lock' objects}
-       98    0.000    0.000    0.021    0.000 threading.py:556(wait)
-      100    0.000    0.000    0.019    0.000 _base.py:201(as_completed)
+      199    0.001    0.000    0.022    0.000 threading.py:280(wait)
+      802    0.022    0.000    0.022    0.000 {method 'acquire' of '_thread.lock' objects}
+      106    0.000    0.000    0.021    0.000 threading.py:556(wait)
+      100    0.000    0.000    0.020    0.000 _base.py:201(as_completed)
       110    0.000    0.000    0.007    0.000 thread.py:155(submit)
       110    0.000    0.000    0.006    0.000 thread.py:174(_adjust_thread_count)
-       10    0.001    0.000    0.005    0.000 coef.py:178(<dictcomp>)
+       10    0.001    0.000    0.004    0.000 coef.py:186(<dictcomp>)
        30    0.000    0.000    0.004    0.000 threading.py:873(start)
        10    0.000    0.000    0.003    0.000 _base.py:572(map)
        10    0.000    0.000    0.003    0.000 _base.py:597(<listcomp>)
-      110    0.000    0.000    0.002    0.000 _base.py:417(result)
-       30    0.000    0.000    0.002    0.000 _base.py:601(result_iterator)
+      110    0.000    0.000    0.001    0.000 _base.py:417(result)
       110    0.000    0.000    0.001    0.000 threading.py:404(acquire)
+       30    0.000    0.000    0.001    0.000 _base.py:601(result_iterator)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_1000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_1000.txt
@@ -1,26 +1,26 @@
-         9620 function calls in 0.069 seconds
+         9576 function calls in 0.069 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
         1    0.000    0.000    0.069    0.069 {built-in method builtins.exec}
-        1    0.000    0.000    0.069    0.069 <string>:1(<module>)
-        1    0.000    0.000    0.069    0.069 1517976664.py:1(func)
-       10    0.001    0.000    0.069    0.007 coef.py:252(cm)
-      224    0.001    0.000    0.056    0.000 threading.py:280(wait)
-      890    0.055    0.000    0.055    0.000 {method 'acquire' of '_thread.lock' objects}
-       10    0.000    0.000    0.052    0.005 coef.py:387(compute_coef)
-       10    0.000    0.000    0.051    0.005 coef.py:380(cdist_func)
-       10    0.002    0.000    0.051    0.005 coef.py:168(cdist_parts_parallel)
-      118    0.000    0.000    0.048    0.000 threading.py:556(wait)
-      100    0.001    0.000    0.044    0.000 _base.py:201(as_completed)
-      110    0.000    0.000    0.009    0.000 thread.py:155(submit)
-      110    0.000    0.000    0.009    0.000 _base.py:417(result)
-       30    0.000    0.000    0.009    0.000 _base.py:601(result_iterator)
-      110    0.000    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.006    0.000 threading.py:873(start)
-       10    0.001    0.000    0.005    0.001 coef.py:178(<dictcomp>)
-       10    0.000    0.000    0.005    0.001 _base.py:572(map)
-       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)
-      110    0.000    0.000    0.001    0.000 threading.py:404(acquire)
+        1    0.000    0.000    0.068    0.068 <string>:1(<module>)
+        1    0.000    0.000    0.068    0.068 1517976664.py:1(func)
+       10    0.001    0.000    0.068    0.007 coef.py:275(cm)
+      884    0.055    0.000    0.055    0.000 {method 'acquire' of '_thread.lock' objects}
+      223    0.001    0.000    0.054    0.000 threading.py:280(wait)
+       10    0.000    0.000    0.051    0.005 coef.py:414(compute_coef)
+       10    0.000    0.000    0.051    0.005 coef.py:407(cdist_func)
+       10    0.001    0.000    0.051    0.005 coef.py:168(cdist_parts_parallel)
+      116    0.000    0.000    0.045    0.000 threading.py:556(wait)
+      100    0.001    0.000    0.042    0.000 _base.py:201(as_completed)
+      110    0.000    0.000    0.010    0.000 _base.py:417(result)
+       30    0.000    0.000    0.010    0.000 _base.py:601(result_iterator)
+      110    0.000    0.000    0.008    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+       10    0.001    0.000    0.007    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.005    0.000 threading.py:873(start)
+       10    0.000    0.000    0.003    0.000 _base.py:572(map)
+       10    0.000    0.000    0.003    0.000 _base.py:597(<listcomp>)
+       10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_50.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_50.txt
@@ -1,4 +1,4 @@
-         6948 function calls in 0.020 seconds
+         6936 function calls in 0.020 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
@@ -7,20 +7,20 @@
         1    0.000    0.000    0.020    0.020 {built-in method builtins.exec}
         1    0.000    0.000    0.020    0.020 <string>:1(<module>)
         1    0.000    0.000    0.020    0.020 1517976664.py:1(func)
-       10    0.001    0.000    0.020    0.002 coef.py:252(cm)
-       10    0.000    0.000    0.014    0.001 coef.py:387(compute_coef)
-       10    0.000    0.000    0.013    0.001 coef.py:380(cdist_func)
+       10    0.001    0.000    0.020    0.002 coef.py:275(cm)
+       10    0.000    0.000    0.014    0.001 coef.py:414(compute_coef)
+       10    0.000    0.000    0.013    0.001 coef.py:407(cdist_func)
        10    0.002    0.000    0.013    0.001 coef.py:168(cdist_parts_parallel)
-      135    0.000    0.000    0.010    0.000 threading.py:280(wait)
-      548    0.010    0.000    0.010    0.000 {method 'acquire' of '_thread.lock' objects}
-       73    0.000    0.000    0.009    0.000 threading.py:556(wait)
+      136    0.000    0.000    0.009    0.000 threading.py:280(wait)
+      554    0.009    0.000    0.009    0.000 {method 'acquire' of '_thread.lock' objects}
+       71    0.000    0.000    0.009    0.000 threading.py:556(wait)
        70    0.000    0.000    0.007    0.000 _base.py:201(as_completed)
-       80    0.000    0.000    0.006    0.000 thread.py:155(submit)
+       80    0.000    0.000    0.005    0.000 thread.py:155(submit)
        80    0.000    0.000    0.005    0.000 thread.py:174(_adjust_thread_count)
-       10    0.000    0.000    0.003    0.000 coef.py:178(<dictcomp>)
+       10    0.000    0.000    0.003    0.000 coef.py:186(<dictcomp>)
        30    0.000    0.000    0.003    0.000 threading.py:873(start)
        10    0.000    0.000    0.003    0.000 _base.py:572(map)
        10    0.000    0.000    0.003    0.000 _base.py:597(<listcomp>)
-       80    0.000    0.000    0.001    0.000 _base.py:417(result)
-       30    0.000    0.000    0.001    0.000 _base.py:601(result_iterator)
+       10    0.001    0.000    0.001    0.000 parallel.py:596(get_num_threads)
        10    0.000    0.000    0.001    0.000 _base.py:635(__exit__)
+       10    0.000    0.000    0.001    0.000 thread.py:210(shutdown)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_500.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/09-n_samples_small_500.txt
@@ -1,26 +1,26 @@
-         9423 function calls in 0.045 seconds
+         9477 function calls in 0.044 seconds
 
    Ordered by: cumulative time
    List reduced from 120 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.045    0.045 {built-in method builtins.exec}
-        1    0.000    0.000    0.045    0.045 <string>:1(<module>)
-        1    0.000    0.000    0.045    0.045 1517976664.py:1(func)
-       10    0.001    0.000    0.045    0.005 coef.py:252(cm)
-       10    0.000    0.000    0.035    0.003 coef.py:387(compute_coef)
-       10    0.000    0.000    0.034    0.003 coef.py:380(cdist_func)
-       10    0.002    0.000    0.034    0.003 coef.py:168(cdist_parts_parallel)
-      214    0.001    0.000    0.033    0.000 threading.py:280(wait)
-      848    0.032    0.000    0.032    0.000 {method 'acquire' of '_thread.lock' objects}
-      111    0.000    0.000    0.028    0.000 threading.py:556(wait)
-      100    0.001    0.000    0.027    0.000 _base.py:201(as_completed)
+        1    0.000    0.000    0.044    0.044 {built-in method builtins.exec}
+        1    0.000    0.000    0.044    0.044 <string>:1(<module>)
+        1    0.000    0.000    0.044    0.044 1517976664.py:1(func)
+       10    0.001    0.000    0.044    0.004 coef.py:275(cm)
+       10    0.000    0.000    0.034    0.003 coef.py:414(compute_coef)
+       10    0.000    0.000    0.033    0.003 coef.py:407(cdist_func)
+       10    0.002    0.000    0.033    0.003 coef.py:168(cdist_parts_parallel)
+      217    0.001    0.000    0.032    0.000 threading.py:280(wait)
+      858    0.031    0.000    0.031    0.000 {method 'acquire' of '_thread.lock' objects}
+      113    0.000    0.000    0.027    0.000 threading.py:556(wait)
+      100    0.001    0.000    0.026    0.000 _base.py:201(as_completed)
       110    0.000    0.000    0.006    0.000 thread.py:155(submit)
-      110    0.000    0.000    0.005    0.000 thread.py:174(_adjust_thread_count)
       110    0.000    0.000    0.005    0.000 _base.py:417(result)
+      110    0.000    0.000    0.005    0.000 thread.py:174(_adjust_thread_count)
        30    0.000    0.000    0.005    0.000 _base.py:601(result_iterator)
-       10    0.001    0.000    0.004    0.000 coef.py:178(<dictcomp>)
+       10    0.001    0.000    0.004    0.000 coef.py:186(<dictcomp>)
        30    0.000    0.000    0.003    0.000 threading.py:873(start)
-       10    0.000    0.000    0.003    0.000 _base.py:572(map)
-       10    0.000    0.000    0.003    0.000 _base.py:597(<listcomp>)
+       10    0.000    0.000    0.002    0.000 _base.py:572(map)
+       10    0.000    0.000    0.002    0.000 _base.py:597(<listcomp>)
       110    0.000    0.000    0.001    0.000 threading.py:404(acquire)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-cdist_parts_v04.ipynb
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-cdist_parts_v04.ipynb
@@ -5,10 +5,10 @@
    "id": "36c65ddb-8246-4b0c-a231-68a373acc2cf",
    "metadata": {
     "papermill": {
-     "duration": 0.133129,
-     "end_time": "2021-11-28T04:48:45.096271",
+     "duration": 0.101131,
+     "end_time": "2021-12-02T04:36:57.333310",
      "exception": false,
-     "start_time": "2021-11-28T04:48:44.963142",
+     "start_time": "2021-12-02T04:36:57.232179",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "337633a8-d03e-4509-b89d-f8daee598958",
    "metadata": {
     "papermill": {
-     "duration": 0.092148,
-     "end_time": "2021-11-28T04:48:45.289085",
+     "duration": 0.093397,
+     "end_time": "2021-12-02T04:36:57.520462",
      "exception": false,
-     "start_time": "2021-11-28T04:48:45.196937",
+     "start_time": "2021-12-02T04:36:57.427065",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "63c2b099-cc44-4fe2-93d1-40336e0a8466",
    "metadata": {
     "papermill": {
-     "duration": 0.092684,
-     "end_time": "2021-11-28T04:48:45.474543",
+     "duration": 0.095211,
+     "end_time": "2021-12-02T04:36:57.716055",
      "exception": false,
-     "start_time": "2021-11-28T04:48:45.381859",
+     "start_time": "2021-12-02T04:36:57.620844",
      "status": "completed"
     },
     "tags": []
@@ -57,16 +57,16 @@
    "id": "20cbd5fd-aeb9-448f-91d9-9ff2d12c9c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:45.668020Z",
-     "iopub.status.busy": "2021-11-28T04:48:45.667465Z",
-     "iopub.status.idle": "2021-11-28T04:48:45.670845Z",
-     "shell.execute_reply": "2021-11-28T04:48:45.670351Z"
+     "iopub.execute_input": "2021-12-02T04:36:57.911147Z",
+     "iopub.status.busy": "2021-12-02T04:36:57.910632Z",
+     "iopub.status.idle": "2021-12-02T04:36:57.914417Z",
+     "shell.execute_reply": "2021-12-02T04:36:57.913918Z"
     },
     "papermill": {
-     "duration": 0.104026,
-     "end_time": "2021-11-28T04:48:45.670947",
+     "duration": 0.105032,
+     "end_time": "2021-12-02T04:36:57.914518",
      "exception": false,
-     "start_time": "2021-11-28T04:48:45.566921",
+     "start_time": "2021-12-02T04:36:57.809486",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "94028e4a-a49a-47b1-94c1-9eddd4e4a488",
    "metadata": {
     "papermill": {
-     "duration": 0.093343,
-     "end_time": "2021-11-28T04:48:45.859095",
+     "duration": 0.095296,
+     "end_time": "2021-12-02T04:36:58.107054",
      "exception": false,
-     "start_time": "2021-11-28T04:48:45.765752",
+     "start_time": "2021-12-02T04:36:58.011758",
      "status": "completed"
     },
     "tags": []
@@ -107,16 +107,16 @@
    "id": "960c4ff0-2a73-4eaa-97d6-3269102233eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:46.049174Z",
-     "iopub.status.busy": "2021-11-28T04:48:46.048700Z",
-     "iopub.status.idle": "2021-11-28T04:48:46.645361Z",
-     "shell.execute_reply": "2021-11-28T04:48:46.643791Z"
+     "iopub.execute_input": "2021-12-02T04:36:58.301605Z",
+     "iopub.status.busy": "2021-12-02T04:36:58.301130Z",
+     "iopub.status.idle": "2021-12-02T04:36:58.896724Z",
+     "shell.execute_reply": "2021-12-02T04:36:58.898251Z"
     },
     "papermill": {
-     "duration": 0.693144,
-     "end_time": "2021-11-28T04:48:46.645753",
+     "duration": 0.695866,
+     "end_time": "2021-12-02T04:36:58.898699",
      "exception": false,
-     "start_time": "2021-11-28T04:48:45.952609",
+     "start_time": "2021-12-02T04:36:58.202833",
      "status": "completed"
     },
     "tags": []
@@ -126,7 +126,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code\n"
+      "/opt/code\r\n"
      ]
     }
    ],
@@ -140,16 +140,16 @@
    "id": "e18db58a-316a-445b-a376-8b2ec18e08d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:46.871045Z",
-     "iopub.status.busy": "2021-11-28T04:48:46.870569Z",
-     "iopub.status.idle": "2021-11-28T04:48:47.472477Z",
-     "shell.execute_reply": "2021-11-28T04:48:47.473925Z"
+     "iopub.execute_input": "2021-12-02T04:36:59.126956Z",
+     "iopub.status.busy": "2021-12-02T04:36:59.126507Z",
+     "iopub.status.idle": "2021-12-02T04:36:59.738873Z",
+     "shell.execute_reply": "2021-12-02T04:36:59.737339Z"
     },
     "papermill": {
-     "duration": 0.701644,
-     "end_time": "2021-11-28T04:48:47.474380",
+     "duration": 0.711841,
+     "end_time": "2021-12-02T04:36:59.739258",
      "exception": false,
-     "start_time": "2021-11-28T04:48:46.772736",
+     "start_time": "2021-12-02T04:36:59.027417",
      "status": "completed"
     },
     "tags": []
@@ -159,10 +159,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code/libs/clustermatch/__pycache__\n",
-      "/opt/code/libs/clustermatch/sklearn/__pycache__\n",
-      "/opt/code/libs/clustermatch/scipy/__pycache__\n",
-      "/opt/code/libs/clustermatch/pytorch/__pycache__\n"
+      "/opt/code/libs/clustermatch/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/sklearn/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/scipy/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/pytorch/__pycache__\r\n"
      ]
     }
    ],
@@ -176,16 +176,16 @@
    "id": "b54099b0-a990-4bbd-bcbd-e206eb0f0f0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:47.700853Z",
-     "iopub.status.busy": "2021-11-28T04:48:47.700396Z",
-     "iopub.status.idle": "2021-11-28T04:48:48.311097Z",
-     "shell.execute_reply": "2021-11-28T04:48:48.309201Z"
+     "iopub.execute_input": "2021-12-02T04:36:59.968702Z",
+     "iopub.status.busy": "2021-12-02T04:36:59.968236Z",
+     "iopub.status.idle": "2021-12-02T04:37:00.578610Z",
+     "shell.execute_reply": "2021-12-02T04:37:00.576770Z"
     },
     "papermill": {
-     "duration": 0.708391,
-     "end_time": "2021-11-28T04:48:48.311474",
+     "duration": 0.710822,
+     "end_time": "2021-12-02T04:37:00.578986",
      "exception": false,
-     "start_time": "2021-11-28T04:48:47.603083",
+     "start_time": "2021-12-02T04:36:59.868164",
      "status": "completed"
     },
     "tags": []
@@ -201,16 +201,16 @@
    "id": "7a9a8098-8160-46bf-8d83-bc398cbe2382",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:48.540298Z",
-     "iopub.status.busy": "2021-11-28T04:48:48.539788Z",
-     "iopub.status.idle": "2021-11-28T04:48:49.129644Z",
-     "shell.execute_reply": "2021-11-28T04:48:49.128776Z"
+     "iopub.execute_input": "2021-12-02T04:37:00.786314Z",
+     "iopub.status.busy": "2021-12-02T04:37:00.785859Z",
+     "iopub.status.idle": "2021-12-02T04:37:01.385162Z",
+     "shell.execute_reply": "2021-12-02T04:37:01.383549Z"
     },
     "papermill": {
-     "duration": 0.690977,
-     "end_time": "2021-11-28T04:48:49.129782",
+     "duration": 0.699623,
+     "end_time": "2021-12-02T04:37:01.385635",
      "exception": false,
-     "start_time": "2021-11-28T04:48:48.438805",
+     "start_time": "2021-12-02T04:37:00.686012",
      "status": "completed"
     },
     "tags": []
@@ -225,10 +225,10 @@
    "id": "c2251313-41ac-46fd-a845-0f209689ecf6",
    "metadata": {
     "papermill": {
-     "duration": 0.094662,
-     "end_time": "2021-11-28T04:48:49.330888",
+     "duration": 0.100188,
+     "end_time": "2021-12-02T04:37:01.613793",
      "exception": false,
-     "start_time": "2021-11-28T04:48:49.236226",
+     "start_time": "2021-12-02T04:37:01.513605",
      "status": "completed"
     },
     "tags": []
@@ -243,16 +243,16 @@
    "id": "987ef5f1-be49-4a6c-a4f4-b24a0a2094cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:49.524467Z",
-     "iopub.status.busy": "2021-11-28T04:48:49.524012Z",
-     "iopub.status.idle": "2021-11-28T04:48:49.828009Z",
-     "shell.execute_reply": "2021-11-28T04:48:49.827612Z"
+     "iopub.execute_input": "2021-12-02T04:37:01.816619Z",
+     "iopub.status.busy": "2021-12-02T04:37:01.816158Z",
+     "iopub.status.idle": "2021-12-02T04:37:02.101993Z",
+     "shell.execute_reply": "2021-12-02T04:37:02.102363Z"
     },
     "papermill": {
-     "duration": 0.402641,
-     "end_time": "2021-11-28T04:48:49.828113",
+     "duration": 0.386175,
+     "end_time": "2021-12-02T04:37:02.102492",
      "exception": false,
-     "start_time": "2021-11-28T04:48:49.425472",
+     "start_time": "2021-12-02T04:37:01.716317",
      "status": "completed"
     },
     "tags": []
@@ -269,10 +269,10 @@
    "id": "24399ccb-d33d-4bad-9baf-638c9c56feb2",
    "metadata": {
     "papermill": {
-     "duration": 0.094914,
-     "end_time": "2021-11-28T04:48:50.018295",
+     "duration": 0.096349,
+     "end_time": "2021-12-02T04:37:02.297213",
      "exception": false,
-     "start_time": "2021-11-28T04:48:49.923381",
+     "start_time": "2021-12-02T04:37:02.200864",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "c609cefa-f513-4cf8-9573-367744e31c5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:50.219648Z",
-     "iopub.status.busy": "2021-11-28T04:48:50.219190Z",
-     "iopub.status.idle": "2021-11-28T04:48:50.220738Z",
-     "shell.execute_reply": "2021-11-28T04:48:50.221089Z"
+     "iopub.execute_input": "2021-12-02T04:37:02.493291Z",
+     "iopub.status.busy": "2021-12-02T04:37:02.492829Z",
+     "iopub.status.idle": "2021-12-02T04:37:02.494753Z",
+     "shell.execute_reply": "2021-12-02T04:37:02.494311Z"
     },
     "papermill": {
-     "duration": 0.108488,
-     "end_time": "2021-11-28T04:48:50.221207",
+     "duration": 0.101239,
+     "end_time": "2021-12-02T04:37:02.494848",
      "exception": false,
-     "start_time": "2021-11-28T04:48:50.112719",
+     "start_time": "2021-12-02T04:37:02.393609",
      "status": "completed"
     },
     "tags": []
@@ -312,16 +312,16 @@
    "id": "c0341a42-b8de-419f-ab37-1e4fee9dde75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:50.413949Z",
-     "iopub.status.busy": "2021-11-28T04:48:50.413492Z",
-     "iopub.status.idle": "2021-11-28T04:48:50.414955Z",
-     "shell.execute_reply": "2021-11-28T04:48:50.415293Z"
+     "iopub.execute_input": "2021-12-02T04:37:02.702329Z",
+     "iopub.status.busy": "2021-12-02T04:37:02.701871Z",
+     "iopub.status.idle": "2021-12-02T04:37:02.703366Z",
+     "shell.execute_reply": "2021-12-02T04:37:02.703704Z"
     },
     "papermill": {
-     "duration": 0.099843,
-     "end_time": "2021-11-28T04:48:50.415409",
+     "duration": 0.1113,
+     "end_time": "2021-12-02T04:37:02.703820",
      "exception": false,
-     "start_time": "2021-11-28T04:48:50.315566",
+     "start_time": "2021-12-02T04:37:02.592520",
      "status": "completed"
     },
     "tags": []
@@ -336,10 +336,10 @@
    "id": "6fd3067b-a4f7-475e-9575-20246934537d",
    "metadata": {
     "papermill": {
-     "duration": 0.094997,
-     "end_time": "2021-11-28T04:48:50.606212",
+     "duration": 0.096196,
+     "end_time": "2021-12-02T04:37:02.897029",
      "exception": false,
-     "start_time": "2021-11-28T04:48:50.511215",
+     "start_time": "2021-12-02T04:37:02.800833",
      "status": "completed"
     },
     "tags": []
@@ -354,16 +354,16 @@
    "id": "02e0507c-43ff-4693-8a3b-8ccd8f23168c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:50.799636Z",
-     "iopub.status.busy": "2021-11-28T04:48:50.799007Z",
-     "iopub.status.idle": "2021-11-28T04:48:50.812023Z",
-     "shell.execute_reply": "2021-11-28T04:48:50.811531Z"
+     "iopub.execute_input": "2021-12-02T04:37:03.093628Z",
+     "iopub.status.busy": "2021-12-02T04:37:03.093157Z",
+     "iopub.status.idle": "2021-12-02T04:37:03.105727Z",
+     "shell.execute_reply": "2021-12-02T04:37:03.105340Z"
     },
     "papermill": {
-     "duration": 0.111135,
-     "end_time": "2021-11-28T04:48:50.812117",
+     "duration": 0.112075,
+     "end_time": "2021-12-02T04:37:03.105822",
      "exception": false,
-     "start_time": "2021-11-28T04:48:50.700982",
+     "start_time": "2021-12-02T04:37:02.993747",
      "status": "completed"
     },
     "tags": []
@@ -390,10 +390,10 @@
    "id": "8549179d-1517-4a40-9a51-b95dc02d0fcc",
    "metadata": {
     "papermill": {
-     "duration": 0.096814,
-     "end_time": "2021-11-28T04:48:51.005348",
+     "duration": 0.096529,
+     "end_time": "2021-12-02T04:37:03.300110",
      "exception": false,
-     "start_time": "2021-11-28T04:48:50.908534",
+     "start_time": "2021-12-02T04:37:03.203581",
      "status": "completed"
     },
     "tags": []
@@ -407,10 +407,10 @@
    "id": "13ba811b",
    "metadata": {
     "papermill": {
-     "duration": 0.103714,
-     "end_time": "2021-11-28T04:48:51.204460",
+     "duration": 0.096047,
+     "end_time": "2021-12-02T04:37:03.492931",
      "exception": false,
-     "start_time": "2021-11-28T04:48:51.100746",
+     "start_time": "2021-12-02T04:37:03.396884",
      "status": "completed"
     },
     "tags": []
@@ -425,16 +425,16 @@
    "id": "68064f0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:51.400556Z",
-     "iopub.status.busy": "2021-11-28T04:48:51.400105Z",
-     "iopub.status.idle": "2021-11-28T04:48:51.401625Z",
-     "shell.execute_reply": "2021-11-28T04:48:51.401964Z"
+     "iopub.execute_input": "2021-12-02T04:37:03.698806Z",
+     "iopub.status.busy": "2021-12-02T04:37:03.698362Z",
+     "iopub.status.idle": "2021-12-02T04:37:03.700293Z",
+     "shell.execute_reply": "2021-12-02T04:37:03.699905Z"
     },
     "papermill": {
-     "duration": 0.101338,
-     "end_time": "2021-11-28T04:48:51.402082",
+     "duration": 0.111014,
+     "end_time": "2021-12-02T04:37:03.700387",
      "exception": false,
-     "start_time": "2021-11-28T04:48:51.300744",
+     "start_time": "2021-12-02T04:37:03.589373",
      "status": "completed"
     },
     "tags": []
@@ -450,16 +450,16 @@
    "id": "6f2ff213-d6b7-458f-acbf-8c73dd497a2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:51.598317Z",
-     "iopub.status.busy": "2021-11-28T04:48:51.597872Z",
-     "iopub.status.idle": "2021-11-28T04:48:51.599825Z",
-     "shell.execute_reply": "2021-11-28T04:48:51.599381Z"
+     "iopub.execute_input": "2021-12-02T04:37:03.899082Z",
+     "iopub.status.busy": "2021-12-02T04:37:03.898619Z",
+     "iopub.status.idle": "2021-12-02T04:37:03.900173Z",
+     "shell.execute_reply": "2021-12-02T04:37:03.900511Z"
     },
     "papermill": {
-     "duration": 0.101757,
-     "end_time": "2021-11-28T04:48:51.599954",
+     "duration": 0.102818,
+     "end_time": "2021-12-02T04:37:03.900627",
      "exception": false,
-     "start_time": "2021-11-28T04:48:51.498197",
+     "start_time": "2021-12-02T04:37:03.797809",
      "status": "completed"
     },
     "tags": []
@@ -476,16 +476,16 @@
    "id": "d63012be-4fc7-4fba-bccd-ad155905d1d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:51.793433Z",
-     "iopub.status.busy": "2021-11-28T04:48:51.792974Z",
-     "iopub.status.idle": "2021-11-28T04:48:51.794539Z",
-     "shell.execute_reply": "2021-11-28T04:48:51.794891Z"
+     "iopub.execute_input": "2021-12-02T04:37:04.100786Z",
+     "iopub.status.busy": "2021-12-02T04:37:04.100336Z",
+     "iopub.status.idle": "2021-12-02T04:37:04.102671Z",
+     "shell.execute_reply": "2021-12-02T04:37:04.102239Z"
     },
     "papermill": {
-     "duration": 0.0999,
-     "end_time": "2021-11-28T04:48:51.795005",
+     "duration": 0.104055,
+     "end_time": "2021-12-02T04:37:04.102764",
      "exception": false,
-     "start_time": "2021-11-28T04:48:51.695105",
+     "start_time": "2021-12-02T04:37:03.998709",
      "status": "completed"
     },
     "tags": []
@@ -503,16 +503,16 @@
    "id": "c0abc65a-2f3c-4476-9c2a-f8d7753b75e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:48:51.990951Z",
-     "iopub.status.busy": "2021-11-28T04:48:51.990485Z",
-     "iopub.status.idle": "2021-11-28T04:49:04.447222Z",
-     "shell.execute_reply": "2021-11-28T04:49:04.446678Z"
+     "iopub.execute_input": "2021-12-02T04:37:04.301684Z",
+     "iopub.status.busy": "2021-12-02T04:37:04.301217Z",
+     "iopub.status.idle": "2021-12-02T04:37:16.833925Z",
+     "shell.execute_reply": "2021-12-02T04:37:16.833506Z"
     },
     "papermill": {
-     "duration": 12.557308,
-     "end_time": "2021-11-28T04:49:04.447336",
+     "duration": 12.634709,
+     "end_time": "2021-12-02T04:37:16.834035",
      "exception": false,
-     "start_time": "2021-11-28T04:48:51.890028",
+     "start_time": "2021-12-02T04:37:04.199326",
      "status": "completed"
     },
     "tags": []
@@ -522,7 +522,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "137 ms ± 9.91 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "141 ms ± 14 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -537,16 +537,16 @@
    "id": "e80a7b02-310f-4bd9-90d5-2a41186db39e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:04.648889Z",
-     "iopub.status.busy": "2021-11-28T04:49:04.648390Z",
-     "iopub.status.idle": "2021-11-28T04:49:04.773812Z",
-     "shell.execute_reply": "2021-11-28T04:49:04.774199Z"
+     "iopub.execute_input": "2021-12-02T04:37:17.040287Z",
+     "iopub.status.busy": "2021-12-02T04:37:17.039804Z",
+     "iopub.status.idle": "2021-12-02T04:37:17.163025Z",
+     "shell.execute_reply": "2021-12-02T04:37:17.162557Z"
     },
     "papermill": {
-     "duration": 0.224868,
-     "end_time": "2021-11-28T04:49:04.774318",
+     "duration": 0.22787,
+     "end_time": "2021-12-02T04:37:17.163123",
      "exception": false,
-     "start_time": "2021-11-28T04:49:04.549450",
+     "start_time": "2021-12-02T04:37:16.935253",
      "status": "completed"
     },
     "tags": []
@@ -571,10 +571,10 @@
    "id": "2548440c",
    "metadata": {
     "papermill": {
-     "duration": 0.095864,
-     "end_time": "2021-11-28T04:49:04.968300",
+     "duration": 0.100385,
+     "end_time": "2021-12-02T04:37:17.364961",
      "exception": false,
-     "start_time": "2021-11-28T04:49:04.872436",
+     "start_time": "2021-12-02T04:37:17.264576",
      "status": "completed"
     },
     "tags": []
@@ -589,16 +589,16 @@
    "id": "ddb768d7-9b74-424c-bdb9-9e52b9e5b181",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:05.164338Z",
-     "iopub.status.busy": "2021-11-28T04:49:05.163819Z",
-     "iopub.status.idle": "2021-11-28T04:49:05.166146Z",
-     "shell.execute_reply": "2021-11-28T04:49:05.165758Z"
+     "iopub.execute_input": "2021-12-02T04:37:17.599561Z",
+     "iopub.status.busy": "2021-12-02T04:37:17.599055Z",
+     "iopub.status.idle": "2021-12-02T04:37:17.600565Z",
+     "shell.execute_reply": "2021-12-02T04:37:17.600913Z"
     },
     "papermill": {
-     "duration": 0.101829,
-     "end_time": "2021-11-28T04:49:05.166254",
+     "duration": 0.111244,
+     "end_time": "2021-12-02T04:37:17.601022",
      "exception": false,
-     "start_time": "2021-11-28T04:49:05.064425",
+     "start_time": "2021-12-02T04:37:17.489778",
      "status": "completed"
     },
     "tags": []
@@ -614,16 +614,16 @@
    "id": "161cf922-41f7-4ced-af1f-e3d25b36b200",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:05.371147Z",
-     "iopub.status.busy": "2021-11-28T04:49:05.370643Z",
-     "iopub.status.idle": "2021-11-28T04:49:05.372195Z",
-     "shell.execute_reply": "2021-11-28T04:49:05.372562Z"
+     "iopub.execute_input": "2021-12-02T04:37:17.809636Z",
+     "iopub.status.busy": "2021-12-02T04:37:17.809179Z",
+     "iopub.status.idle": "2021-12-02T04:37:17.811012Z",
+     "shell.execute_reply": "2021-12-02T04:37:17.810630Z"
     },
     "papermill": {
-     "duration": 0.100953,
-     "end_time": "2021-11-28T04:49:05.372679",
+     "duration": 0.105356,
+     "end_time": "2021-12-02T04:37:17.811111",
      "exception": false,
-     "start_time": "2021-11-28T04:49:05.271726",
+     "start_time": "2021-12-02T04:37:17.705755",
      "status": "completed"
     },
     "tags": []
@@ -640,16 +640,16 @@
    "id": "ede7a328-bad3-40a2-a179-1148a3229620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:05.569277Z",
-     "iopub.status.busy": "2021-11-28T04:49:05.568842Z",
-     "iopub.status.idle": "2021-11-28T04:49:05.570948Z",
-     "shell.execute_reply": "2021-11-28T04:49:05.570508Z"
+     "iopub.execute_input": "2021-12-02T04:37:18.013003Z",
+     "iopub.status.busy": "2021-12-02T04:37:18.012549Z",
+     "iopub.status.idle": "2021-12-02T04:37:18.014398Z",
+     "shell.execute_reply": "2021-12-02T04:37:18.014016Z"
     },
     "papermill": {
-     "duration": 0.101721,
-     "end_time": "2021-11-28T04:49:05.571041",
+     "duration": 0.104201,
+     "end_time": "2021-12-02T04:37:18.014491",
      "exception": false,
-     "start_time": "2021-11-28T04:49:05.469320",
+     "start_time": "2021-12-02T04:37:17.910290",
      "status": "completed"
     },
     "tags": []
@@ -667,16 +667,16 @@
    "id": "0a7f2b1f-4b87-4dde-a46b-2acec5ac93ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:05.769409Z",
-     "iopub.status.busy": "2021-11-28T04:49:05.768885Z",
-     "iopub.status.idle": "2021-11-28T04:49:12.603673Z",
-     "shell.execute_reply": "2021-11-28T04:49:12.603169Z"
+     "iopub.execute_input": "2021-12-02T04:37:18.220053Z",
+     "iopub.status.busy": "2021-12-02T04:37:18.219419Z",
+     "iopub.status.idle": "2021-12-02T04:37:24.963506Z",
+     "shell.execute_reply": "2021-12-02T04:37:24.962993Z"
     },
     "papermill": {
-     "duration": 6.935569,
-     "end_time": "2021-11-28T04:49:12.603781",
+     "duration": 6.84888,
+     "end_time": "2021-12-02T04:37:24.963614",
      "exception": false,
-     "start_time": "2021-11-28T04:49:05.668212",
+     "start_time": "2021-12-02T04:37:18.114734",
      "status": "completed"
     },
     "tags": []
@@ -686,7 +686,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "431 ms ± 49 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "428 ms ± 39.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -701,16 +701,16 @@
    "id": "74acbe27-9807-4f26-8b7e-b74d0f745b63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:12.805511Z",
-     "iopub.status.busy": "2021-11-28T04:49:12.805009Z",
-     "iopub.status.idle": "2021-11-28T04:49:13.162728Z",
-     "shell.execute_reply": "2021-11-28T04:49:13.162328Z"
+     "iopub.execute_input": "2021-12-02T04:37:25.171582Z",
+     "iopub.status.busy": "2021-12-02T04:37:25.170725Z",
+     "iopub.status.idle": "2021-12-02T04:37:25.532258Z",
+     "shell.execute_reply": "2021-12-02T04:37:25.531874Z"
     },
     "papermill": {
-     "duration": 0.458857,
-     "end_time": "2021-11-28T04:49:13.162829",
+     "duration": 0.465279,
+     "end_time": "2021-12-02T04:37:25.532358",
      "exception": false,
-     "start_time": "2021-11-28T04:49:12.703972",
+     "start_time": "2021-12-02T04:37:25.067079",
      "status": "completed"
     },
     "tags": []
@@ -735,10 +735,10 @@
    "id": "611ff8e1",
    "metadata": {
     "papermill": {
-     "duration": 0.124382,
-     "end_time": "2021-11-28T04:49:13.395162",
+     "duration": 0.10645,
+     "end_time": "2021-12-02T04:37:25.742045",
      "exception": false,
-     "start_time": "2021-11-28T04:49:13.270780",
+     "start_time": "2021-12-02T04:37:25.635595",
      "status": "completed"
     },
     "tags": []
@@ -753,16 +753,16 @@
    "id": "4bcf4b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:13.610801Z",
-     "iopub.status.busy": "2021-11-28T04:49:13.610330Z",
-     "iopub.status.idle": "2021-11-28T04:49:13.611782Z",
-     "shell.execute_reply": "2021-11-28T04:49:13.612157Z"
+     "iopub.execute_input": "2021-12-02T04:37:25.946981Z",
+     "iopub.status.busy": "2021-12-02T04:37:25.946503Z",
+     "iopub.status.idle": "2021-12-02T04:37:25.947981Z",
+     "shell.execute_reply": "2021-12-02T04:37:25.948333Z"
     },
     "papermill": {
-     "duration": 0.105945,
-     "end_time": "2021-11-28T04:49:13.612274",
+     "duration": 0.105745,
+     "end_time": "2021-12-02T04:37:25.948446",
      "exception": false,
-     "start_time": "2021-11-28T04:49:13.506329",
+     "start_time": "2021-12-02T04:37:25.842701",
      "status": "completed"
     },
     "tags": []
@@ -778,16 +778,16 @@
    "id": "0bf2f21e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:13.817094Z",
-     "iopub.status.busy": "2021-11-28T04:49:13.816585Z",
-     "iopub.status.idle": "2021-11-28T04:49:13.818055Z",
-     "shell.execute_reply": "2021-11-28T04:49:13.818434Z"
+     "iopub.execute_input": "2021-12-02T04:37:26.152110Z",
+     "iopub.status.busy": "2021-12-02T04:37:26.151591Z",
+     "iopub.status.idle": "2021-12-02T04:37:26.153920Z",
+     "shell.execute_reply": "2021-12-02T04:37:26.153472Z"
     },
     "papermill": {
-     "duration": 0.10433,
-     "end_time": "2021-11-28T04:49:13.818563",
+     "duration": 0.105277,
+     "end_time": "2021-12-02T04:37:26.154017",
      "exception": false,
-     "start_time": "2021-11-28T04:49:13.714233",
+     "start_time": "2021-12-02T04:37:26.048740",
      "status": "completed"
     },
     "tags": []
@@ -804,16 +804,16 @@
    "id": "24c352bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:14.025391Z",
-     "iopub.status.busy": "2021-11-28T04:49:14.024938Z",
-     "iopub.status.idle": "2021-11-28T04:49:14.026429Z",
-     "shell.execute_reply": "2021-11-28T04:49:14.026826Z"
+     "iopub.execute_input": "2021-12-02T04:37:26.357429Z",
+     "iopub.status.busy": "2021-12-02T04:37:26.356978Z",
+     "iopub.status.idle": "2021-12-02T04:37:26.358844Z",
+     "shell.execute_reply": "2021-12-02T04:37:26.358481Z"
     },
     "papermill": {
-     "duration": 0.107701,
-     "end_time": "2021-11-28T04:49:14.026940",
+     "duration": 0.104548,
+     "end_time": "2021-12-02T04:37:26.358940",
      "exception": false,
-     "start_time": "2021-11-28T04:49:13.919239",
+     "start_time": "2021-12-02T04:37:26.254392",
      "status": "completed"
     },
     "tags": []
@@ -831,16 +831,16 @@
    "id": "cbde4ce6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:14.235476Z",
-     "iopub.status.busy": "2021-11-28T04:49:14.234960Z",
-     "iopub.status.idle": "2021-11-28T04:49:20.958755Z",
-     "shell.execute_reply": "2021-11-28T04:49:20.958292Z"
+     "iopub.execute_input": "2021-12-02T04:37:26.563098Z",
+     "iopub.status.busy": "2021-12-02T04:37:26.562627Z",
+     "iopub.status.idle": "2021-12-02T04:37:33.801602Z",
+     "shell.execute_reply": "2021-12-02T04:37:33.801037Z"
     },
     "papermill": {
-     "duration": 6.831906,
-     "end_time": "2021-11-28T04:49:20.958854",
+     "duration": 7.342849,
+     "end_time": "2021-12-02T04:37:33.801721",
      "exception": false,
-     "start_time": "2021-11-28T04:49:14.126948",
+     "start_time": "2021-12-02T04:37:26.458872",
      "status": "completed"
     },
     "tags": []
@@ -850,7 +850,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "424 ms ± 24.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "441 ms ± 24.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -865,16 +865,16 @@
    "id": "1250547e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:21.164472Z",
-     "iopub.status.busy": "2021-11-28T04:49:21.163931Z",
-     "iopub.status.idle": "2021-11-28T04:49:21.644595Z",
-     "shell.execute_reply": "2021-11-28T04:49:21.645043Z"
+     "iopub.execute_input": "2021-12-02T04:37:34.015314Z",
+     "iopub.status.busy": "2021-12-02T04:37:34.014832Z",
+     "iopub.status.idle": "2021-12-02T04:37:34.410262Z",
+     "shell.execute_reply": "2021-12-02T04:37:34.410651Z"
     },
     "papermill": {
-     "duration": 0.584886,
-     "end_time": "2021-11-28T04:49:21.645192",
+     "duration": 0.501944,
+     "end_time": "2021-12-02T04:37:34.410769",
      "exception": false,
-     "start_time": "2021-11-28T04:49:21.060306",
+     "start_time": "2021-12-02T04:37:33.908825",
      "status": "completed"
     },
     "tags": []
@@ -899,10 +899,10 @@
    "id": "6853c300",
    "metadata": {
     "papermill": {
-     "duration": 0.100719,
-     "end_time": "2021-11-28T04:49:21.850787",
+     "duration": 0.103261,
+     "end_time": "2021-12-02T04:37:34.618220",
      "exception": false,
-     "start_time": "2021-11-28T04:49:21.750068",
+     "start_time": "2021-12-02T04:37:34.514959",
      "status": "completed"
     },
     "tags": []
@@ -917,16 +917,16 @@
    "id": "f77e8490",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:22.054184Z",
-     "iopub.status.busy": "2021-11-28T04:49:22.053715Z",
-     "iopub.status.idle": "2021-11-28T04:49:22.055340Z",
-     "shell.execute_reply": "2021-11-28T04:49:22.055674Z"
+     "iopub.execute_input": "2021-12-02T04:37:34.832465Z",
+     "iopub.status.busy": "2021-12-02T04:37:34.831999Z",
+     "iopub.status.idle": "2021-12-02T04:37:34.833958Z",
+     "shell.execute_reply": "2021-12-02T04:37:34.833511Z"
     },
     "papermill": {
-     "duration": 0.105693,
-     "end_time": "2021-11-28T04:49:22.055792",
+     "duration": 0.114715,
+     "end_time": "2021-12-02T04:37:34.834052",
      "exception": false,
-     "start_time": "2021-11-28T04:49:21.950099",
+     "start_time": "2021-12-02T04:37:34.719337",
      "status": "completed"
     },
     "tags": []
@@ -942,16 +942,16 @@
    "id": "c99f544a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:22.264227Z",
-     "iopub.status.busy": "2021-11-28T04:49:22.263686Z",
-     "iopub.status.idle": "2021-11-28T04:49:22.265788Z",
-     "shell.execute_reply": "2021-11-28T04:49:22.265253Z"
+     "iopub.execute_input": "2021-12-02T04:37:35.043108Z",
+     "iopub.status.busy": "2021-12-02T04:37:35.042636Z",
+     "iopub.status.idle": "2021-12-02T04:37:35.044239Z",
+     "shell.execute_reply": "2021-12-02T04:37:35.044579Z"
     },
     "papermill": {
-     "duration": 0.109726,
-     "end_time": "2021-11-28T04:49:22.265899",
+     "duration": 0.107686,
+     "end_time": "2021-12-02T04:37:35.044696",
      "exception": false,
-     "start_time": "2021-11-28T04:49:22.156173",
+     "start_time": "2021-12-02T04:37:34.937010",
      "status": "completed"
     },
     "tags": []
@@ -968,16 +968,16 @@
    "id": "d907f1d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:22.471274Z",
-     "iopub.status.busy": "2021-11-28T04:49:22.470812Z",
-     "iopub.status.idle": "2021-11-28T04:49:22.472792Z",
-     "shell.execute_reply": "2021-11-28T04:49:22.472410Z"
+     "iopub.execute_input": "2021-12-02T04:37:35.253125Z",
+     "iopub.status.busy": "2021-12-02T04:37:35.252650Z",
+     "iopub.status.idle": "2021-12-02T04:37:35.254497Z",
+     "shell.execute_reply": "2021-12-02T04:37:35.254118Z"
     },
     "papermill": {
-     "duration": 0.10543,
-     "end_time": "2021-11-28T04:49:22.472889",
+     "duration": 0.106501,
+     "end_time": "2021-12-02T04:37:35.254591",
      "exception": false,
-     "start_time": "2021-11-28T04:49:22.367459",
+     "start_time": "2021-12-02T04:37:35.148090",
      "status": "completed"
     },
     "tags": []
@@ -995,16 +995,16 @@
    "id": "9721b048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:22.679772Z",
-     "iopub.status.busy": "2021-11-28T04:49:22.678494Z",
-     "iopub.status.idle": "2021-11-28T04:49:36.263285Z",
-     "shell.execute_reply": "2021-11-28T04:49:36.262823Z"
+     "iopub.execute_input": "2021-12-02T04:37:35.461330Z",
+     "iopub.status.busy": "2021-12-02T04:37:35.460856Z",
+     "iopub.status.idle": "2021-12-02T04:37:49.189938Z",
+     "shell.execute_reply": "2021-12-02T04:37:49.190314Z"
     },
     "papermill": {
-     "duration": 13.689829,
-     "end_time": "2021-11-28T04:49:36.263384",
+     "duration": 13.834783,
+     "end_time": "2021-12-02T04:37:49.190434",
      "exception": false,
-     "start_time": "2021-11-28T04:49:22.573555",
+     "start_time": "2021-12-02T04:37:35.355651",
      "status": "completed"
     },
     "tags": []
@@ -1014,7 +1014,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "850 ms ± 4.74 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "858 ms ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1029,16 +1029,16 @@
    "id": "fd0f4dd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:36.478508Z",
-     "iopub.status.busy": "2021-11-28T04:49:36.478030Z",
-     "iopub.status.idle": "2021-11-28T04:49:37.340061Z",
-     "shell.execute_reply": "2021-11-28T04:49:37.339559Z"
+     "iopub.execute_input": "2021-12-02T04:37:49.400379Z",
+     "iopub.status.busy": "2021-12-02T04:37:49.399912Z",
+     "iopub.status.idle": "2021-12-02T04:37:50.269813Z",
+     "shell.execute_reply": "2021-12-02T04:37:50.270191Z"
     },
     "papermill": {
-     "duration": 0.967267,
-     "end_time": "2021-11-28T04:49:37.340174",
+     "duration": 0.97614,
+     "end_time": "2021-12-02T04:37:50.270311",
      "exception": false,
-     "start_time": "2021-11-28T04:49:36.372907",
+     "start_time": "2021-12-02T04:37:49.294171",
      "status": "completed"
     },
     "tags": []
@@ -1061,7 +1061,16 @@
   {
    "cell_type": "markdown",
    "id": "fb1a50ab-a34a-4705-bb3d-e9d6278a30c5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.103807,
+     "end_time": "2021-12-02T04:37:50.477116",
+     "exception": false,
+     "start_time": "2021-12-02T04:37:50.373309",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**CONCLUSION:** as expected, with relatively small samples, the numba-compiled version (`09-cdist_parts_v04`) performs much better than the non-compiled one."
    ]
@@ -1071,10 +1080,10 @@
    "id": "f6b9adcf-1da4-4496-b05f-47952fd80d7f",
    "metadata": {
     "papermill": {
-     "duration": 0.102365,
-     "end_time": "2021-11-28T04:49:37.547220",
+     "duration": 0.103785,
+     "end_time": "2021-12-02T04:37:50.684395",
      "exception": false,
-     "start_time": "2021-11-28T04:49:37.444855",
+     "start_time": "2021-12-02T04:37:50.580610",
      "status": "completed"
     },
     "tags": []
@@ -1088,10 +1097,10 @@
    "id": "8f2e407c",
    "metadata": {
     "papermill": {
-     "duration": 0.100776,
-     "end_time": "2021-11-28T04:49:37.749892",
+     "duration": 0.109125,
+     "end_time": "2021-12-02T04:37:50.896687",
      "exception": false,
-     "start_time": "2021-11-28T04:49:37.649116",
+     "start_time": "2021-12-02T04:37:50.787562",
      "status": "completed"
     },
     "tags": []
@@ -1106,16 +1115,16 @@
    "id": "c522396e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:37.955661Z",
-     "iopub.status.busy": "2021-11-28T04:49:37.955221Z",
-     "iopub.status.idle": "2021-11-28T04:49:37.957586Z",
-     "shell.execute_reply": "2021-11-28T04:49:37.957142Z"
+     "iopub.execute_input": "2021-12-02T04:37:51.105200Z",
+     "iopub.status.busy": "2021-12-02T04:37:51.104752Z",
+     "iopub.status.idle": "2021-12-02T04:37:51.106157Z",
+     "shell.execute_reply": "2021-12-02T04:37:51.106510Z"
     },
     "papermill": {
-     "duration": 0.106316,
-     "end_time": "2021-11-28T04:49:37.957681",
+     "duration": 0.107277,
+     "end_time": "2021-12-02T04:37:51.106621",
      "exception": false,
-     "start_time": "2021-11-28T04:49:37.851365",
+     "start_time": "2021-12-02T04:37:50.999344",
      "status": "completed"
     },
     "tags": []
@@ -1131,16 +1140,16 @@
    "id": "a5e536cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:38.166095Z",
-     "iopub.status.busy": "2021-11-28T04:49:38.165555Z",
-     "iopub.status.idle": "2021-11-28T04:49:38.168338Z",
-     "shell.execute_reply": "2021-11-28T04:49:38.168688Z"
+     "iopub.execute_input": "2021-12-02T04:37:51.315976Z",
+     "iopub.status.busy": "2021-12-02T04:37:51.315458Z",
+     "iopub.status.idle": "2021-12-02T04:37:51.318127Z",
+     "shell.execute_reply": "2021-12-02T04:37:51.317763Z"
     },
     "papermill": {
-     "duration": 0.108098,
-     "end_time": "2021-11-28T04:49:38.168801",
+     "duration": 0.108638,
+     "end_time": "2021-12-02T04:37:51.318226",
      "exception": false,
-     "start_time": "2021-11-28T04:49:38.060703",
+     "start_time": "2021-12-02T04:37:51.209588",
      "status": "completed"
     },
     "tags": []
@@ -1157,16 +1166,16 @@
    "id": "15cb532e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:38.382879Z",
-     "iopub.status.busy": "2021-11-28T04:49:38.382410Z",
-     "iopub.status.idle": "2021-11-28T04:49:38.384635Z",
-     "shell.execute_reply": "2021-11-28T04:49:38.384201Z"
+     "iopub.execute_input": "2021-12-02T04:37:51.529025Z",
+     "iopub.status.busy": "2021-12-02T04:37:51.528568Z",
+     "iopub.status.idle": "2021-12-02T04:37:51.530041Z",
+     "shell.execute_reply": "2021-12-02T04:37:51.530382Z"
     },
     "papermill": {
-     "duration": 0.114217,
-     "end_time": "2021-11-28T04:49:38.384727",
+     "duration": 0.107088,
+     "end_time": "2021-12-02T04:37:51.530499",
      "exception": false,
-     "start_time": "2021-11-28T04:49:38.270510",
+     "start_time": "2021-12-02T04:37:51.423411",
      "status": "completed"
     },
     "tags": []
@@ -1184,16 +1193,16 @@
    "id": "91470f64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:49:38.592626Z",
-     "iopub.status.busy": "2021-11-28T04:49:38.591969Z",
-     "iopub.status.idle": "2021-11-28T04:50:11.652605Z",
-     "shell.execute_reply": "2021-11-28T04:50:11.652954Z"
+     "iopub.execute_input": "2021-12-02T04:37:51.741002Z",
+     "iopub.status.busy": "2021-12-02T04:37:51.740365Z",
+     "iopub.status.idle": "2021-12-02T04:38:27.435619Z",
+     "shell.execute_reply": "2021-12-02T04:38:27.436034Z"
     },
     "papermill": {
-     "duration": 33.166052,
-     "end_time": "2021-11-28T04:50:11.653058",
+     "duration": 35.80273,
+     "end_time": "2021-12-02T04:38:27.436145",
      "exception": false,
-     "start_time": "2021-11-28T04:49:38.487006",
+     "start_time": "2021-12-02T04:37:51.633415",
      "status": "completed"
     },
     "tags": []
@@ -1203,7 +1212,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.06 s ± 8.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.23 s ± 10.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1218,16 +1227,16 @@
    "id": "4de4e0b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:50:11.860427Z",
-     "iopub.status.busy": "2021-11-28T04:50:11.859816Z",
-     "iopub.status.idle": "2021-11-28T04:50:13.918712Z",
-     "shell.execute_reply": "2021-11-28T04:50:13.918316Z"
+     "iopub.execute_input": "2021-12-02T04:38:27.648543Z",
+     "iopub.status.busy": "2021-12-02T04:38:27.647940Z",
+     "iopub.status.idle": "2021-12-02T04:38:29.880143Z",
+     "shell.execute_reply": "2021-12-02T04:38:29.879649Z"
     },
     "papermill": {
-     "duration": 2.164387,
-     "end_time": "2021-11-28T04:50:13.918809",
+     "duration": 2.340044,
+     "end_time": "2021-12-02T04:38:29.880241",
      "exception": false,
-     "start_time": "2021-11-28T04:50:11.754422",
+     "start_time": "2021-12-02T04:38:27.540197",
      "status": "completed"
     },
     "tags": []
@@ -1252,10 +1261,10 @@
    "id": "b0c07894",
    "metadata": {
     "papermill": {
-     "duration": 0.102788,
-     "end_time": "2021-11-28T04:50:14.124878",
+     "duration": 0.105829,
+     "end_time": "2021-12-02T04:38:30.098264",
      "exception": false,
-     "start_time": "2021-11-28T04:50:14.022090",
+     "start_time": "2021-12-02T04:38:29.992435",
      "status": "completed"
     },
     "tags": []
@@ -1270,16 +1279,16 @@
    "id": "7fb2ab2e-a6de-412b-9540-d00f8641290e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:50:14.333111Z",
-     "iopub.status.busy": "2021-11-28T04:50:14.332626Z",
-     "iopub.status.idle": "2021-11-28T04:50:14.334866Z",
-     "shell.execute_reply": "2021-11-28T04:50:14.334409Z"
+     "iopub.execute_input": "2021-12-02T04:38:30.310087Z",
+     "iopub.status.busy": "2021-12-02T04:38:30.309651Z",
+     "iopub.status.idle": "2021-12-02T04:38:30.311339Z",
+     "shell.execute_reply": "2021-12-02T04:38:30.311682Z"
     },
     "papermill": {
-     "duration": 0.107832,
-     "end_time": "2021-11-28T04:50:14.334964",
+     "duration": 0.109597,
+     "end_time": "2021-12-02T04:38:30.311799",
      "exception": false,
-     "start_time": "2021-11-28T04:50:14.227132",
+     "start_time": "2021-12-02T04:38:30.202202",
      "status": "completed"
     },
     "tags": []
@@ -1295,16 +1304,16 @@
    "id": "81765e91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:50:14.550873Z",
-     "iopub.status.busy": "2021-11-28T04:50:14.550431Z",
-     "iopub.status.idle": "2021-11-28T04:50:14.554032Z",
-     "shell.execute_reply": "2021-11-28T04:50:14.553590Z"
+     "iopub.execute_input": "2021-12-02T04:38:30.525019Z",
+     "iopub.status.busy": "2021-12-02T04:38:30.524568Z",
+     "iopub.status.idle": "2021-12-02T04:38:30.528283Z",
+     "shell.execute_reply": "2021-12-02T04:38:30.527854Z"
     },
     "papermill": {
-     "duration": 0.115762,
-     "end_time": "2021-11-28T04:50:14.554128",
+     "duration": 0.111647,
+     "end_time": "2021-12-02T04:38:30.528379",
      "exception": false,
-     "start_time": "2021-11-28T04:50:14.438366",
+     "start_time": "2021-12-02T04:38:30.416732",
      "status": "completed"
     },
     "tags": []
@@ -1321,16 +1330,16 @@
    "id": "d408b318",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:50:14.763263Z",
-     "iopub.status.busy": "2021-11-28T04:50:14.762806Z",
-     "iopub.status.idle": "2021-11-28T04:50:14.764472Z",
-     "shell.execute_reply": "2021-11-28T04:50:14.764874Z"
+     "iopub.execute_input": "2021-12-02T04:38:30.742827Z",
+     "iopub.status.busy": "2021-12-02T04:38:30.742345Z",
+     "iopub.status.idle": "2021-12-02T04:38:30.744280Z",
+     "shell.execute_reply": "2021-12-02T04:38:30.743848Z"
     },
     "papermill": {
-     "duration": 0.108356,
-     "end_time": "2021-11-28T04:50:14.764985",
+     "duration": 0.110384,
+     "end_time": "2021-12-02T04:38:30.744375",
      "exception": false,
-     "start_time": "2021-11-28T04:50:14.656629",
+     "start_time": "2021-12-02T04:38:30.633991",
      "status": "completed"
     },
     "tags": []
@@ -1348,16 +1357,16 @@
    "id": "aca57100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:50:14.976209Z",
-     "iopub.status.busy": "2021-11-28T04:50:14.974078Z",
-     "iopub.status.idle": "2021-11-28T04:51:17.270623Z",
-     "shell.execute_reply": "2021-11-28T04:51:17.270973Z"
+     "iopub.execute_input": "2021-12-02T04:38:30.958831Z",
+     "iopub.status.busy": "2021-12-02T04:38:30.958256Z",
+     "iopub.status.idle": "2021-12-02T04:39:38.969951Z",
+     "shell.execute_reply": "2021-12-02T04:39:38.970301Z"
     },
     "papermill": {
-     "duration": 62.402236,
-     "end_time": "2021-11-28T04:51:17.271086",
+     "duration": 68.120109,
+     "end_time": "2021-12-02T04:39:38.970413",
      "exception": false,
-     "start_time": "2021-11-28T04:50:14.868850",
+     "start_time": "2021-12-02T04:38:30.850304",
      "status": "completed"
     },
     "tags": []
@@ -1367,7 +1376,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.88 s ± 5.12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "4.25 s ± 11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1382,16 +1391,16 @@
    "id": "b9c25f30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:17.482313Z",
-     "iopub.status.busy": "2021-11-28T04:51:17.481577Z",
-     "iopub.status.idle": "2021-11-28T04:51:21.382437Z",
-     "shell.execute_reply": "2021-11-28T04:51:21.381997Z"
+     "iopub.execute_input": "2021-12-02T04:39:39.183942Z",
+     "iopub.status.busy": "2021-12-02T04:39:39.183247Z",
+     "iopub.status.idle": "2021-12-02T04:39:43.450962Z",
+     "shell.execute_reply": "2021-12-02T04:39:43.451362Z"
     },
     "papermill": {
-     "duration": 4.007818,
-     "end_time": "2021-11-28T04:51:21.382530",
+     "duration": 4.37642,
+     "end_time": "2021-12-02T04:39:43.451480",
      "exception": false,
-     "start_time": "2021-11-28T04:51:17.374712",
+     "start_time": "2021-12-02T04:39:39.075060",
      "status": "completed"
     },
     "tags": []
@@ -1414,7 +1423,16 @@
   {
    "cell_type": "markdown",
    "id": "3719e9b9-c895-4492-924b-b10388d52ce4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.104171,
+     "end_time": "2021-12-02T04:39:43.662835",
+     "exception": false,
+     "start_time": "2021-12-02T04:39:43.558664",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**CONCLUSION:** this is unexpected. With very large samples, the python version performs better! Something to look at in the future. The profiling file for 100,000 samples () shows that the `cdist_parts_parallel` is taking more time in the numba-compiled version than in the python version. Maybe the compiled ARI implementation could be improved in these cases with large samples."
    ]
@@ -1425,10 +1443,10 @@
    "id": "2aa76596-f126-4ba8-8bba-4d31225e0e5d",
    "metadata": {
     "papermill": {
-     "duration": 0.10415,
-     "end_time": "2021-11-28T04:51:21.590374",
+     "duration": 0.105499,
+     "end_time": "2021-12-02T04:39:43.873333",
      "exception": false,
-     "start_time": "2021-11-28T04:51:21.486224",
+     "start_time": "2021-12-02T04:39:43.767834",
      "status": "completed"
     },
     "tags": []
@@ -1439,13 +1457,7 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1466,14 +1478,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 158.149177,
-   "end_time": "2021-11-28T04:51:21.901548",
+   "duration": 168.306551,
+   "end_time": "2021-12-02T04:39:44.188549",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/10_cm_optimized/10-cdist_parts_v04.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/10_cm_optimized/10-cdist_parts_v04.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T04:48:43.752371",
+   "start_time": "2021-12-02T04:36:55.881998",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_large_100000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_large_100000.txt
@@ -1,26 +1,26 @@
-         9829 function calls (9819 primitive calls) in 3.896 seconds
+         9838 function calls (9828 primitive calls) in 4.263 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    3.896    3.896 {built-in method builtins.exec}
-        1    0.000    0.000    3.896    3.896 <string>:1(<module>)
-        1    0.000    0.000    3.896    3.896 1517976664.py:1(func)
-       10    0.005    0.000    3.896    0.390 coef.py:252(cm)
-      220    0.001    0.000    3.867    0.018 threading.py:280(wait)
-      890    3.866    0.004    3.866    0.004 {method 'acquire' of '_thread.lock' objects}
-       10    0.000    0.000    2.686    0.269 coef.py:387(compute_coef)
-       10    0.000    0.000    2.685    0.269 coef.py:380(cdist_func)
-       10    0.003    0.000    2.685    0.269 coef.py:168(cdist_parts_parallel)
-      120    0.000    0.000    2.673    0.022 threading.py:556(wait)
-      100    0.001    0.000    2.666    0.027 _base.py:201(as_completed)
-      110    0.000    0.000    1.195    0.011 _base.py:417(result)
-       30    0.000    0.000    1.194    0.040 _base.py:601(result_iterator)
-       10    0.005    0.001    0.015    0.002 coef.py:178(<dictcomp>)
-      110    0.001    0.000    0.015    0.000 thread.py:155(submit)
-      110    0.001    0.000    0.013    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.010    0.000 threading.py:873(start)
-       10    0.000    0.000    0.005    0.000 _base.py:572(map)
-       10    0.000    0.000    0.005    0.000 _base.py:597(<listcomp>)
-       10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)
+        1    0.000    0.000    4.263    4.263 {built-in method builtins.exec}
+        1    0.000    0.000    4.263    4.263 <string>:1(<module>)
+        1    0.000    0.000    4.263    4.263 1517976664.py:1(func)
+       10    0.005    0.001    4.263    0.426 coef.py:275(cm)
+      221    0.001    0.000    4.234    0.019 threading.py:280(wait)
+      892    4.234    0.005    4.234    0.005 {method 'acquire' of '_thread.lock' objects}
+       10    0.000    0.000    2.689    0.269 coef.py:414(compute_coef)
+       10    0.000    0.000    2.688    0.269 coef.py:407(cdist_func)
+       10    0.003    0.000    2.688    0.269 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    2.676    0.022 threading.py:556(wait)
+      100    0.001    0.000    2.675    0.027 _base.py:201(as_completed)
+      110    0.000    0.000    1.559    0.014 _base.py:417(result)
+       30    0.000    0.000    1.559    0.052 _base.py:601(result_iterator)
+       10    0.004    0.000    0.009    0.001 coef.py:186(<dictcomp>)
+      110    0.001    0.000    0.009    0.000 thread.py:155(submit)
+      110    0.001    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
+       30    0.000    0.000    0.005    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+       50    0.003    0.000    0.003    0.000 {built-in method numpy.zeros}

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_large_50000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_large_50000.txt
@@ -1,26 +1,26 @@
-         9825 function calls (9815 primitive calls) in 2.055 seconds
+         9867 function calls (9857 primitive calls) in 2.227 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    2.055    2.055 {built-in method builtins.exec}
-        1    0.000    0.000    2.055    2.055 <string>:1(<module>)
-        1    0.000    0.000    2.055    2.055 1517976664.py:1(func)
-       10    0.002    0.000    2.055    0.205 coef.py:252(cm)
-      220    0.001    0.000    2.033    0.009 threading.py:280(wait)
-      890    2.032    0.002    2.032    0.002 {method 'acquire' of '_thread.lock' objects}
-       10    0.000    0.000    1.495    0.149 coef.py:387(compute_coef)
-       10    0.000    0.000    1.494    0.149 coef.py:380(cdist_func)
-       10    0.003    0.000    1.493    0.149 coef.py:168(cdist_parts_parallel)
-      120    0.000    0.000    1.484    0.012 threading.py:556(wait)
-      100    0.001    0.000    1.483    0.015 _base.py:201(as_completed)
-      110    0.000    0.000    0.549    0.005 _base.py:417(result)
-       30    0.000    0.000    0.549    0.018 _base.py:601(result_iterator)
-      110    0.001    0.000    0.008    0.000 thread.py:155(submit)
-       10    0.003    0.000    0.007    0.001 coef.py:178(<dictcomp>)
+        1    0.000    0.000    2.227    2.227 {built-in method builtins.exec}
+        1    0.000    0.000    2.227    2.227 <string>:1(<module>)
+        1    0.001    0.001    2.227    2.227 1517976664.py:1(func)
+       10    0.003    0.000    2.227    0.223 coef.py:275(cm)
+      225    0.001    0.000    2.204    0.010 threading.py:280(wait)
+      900    2.203    0.002    2.203    0.002 {method 'acquire' of '_thread.lock' objects}
+       10    0.000    0.000    1.502    0.150 coef.py:414(compute_coef)
+       10    0.000    0.000    1.501    0.150 coef.py:407(cdist_func)
+       10    0.003    0.000    1.501    0.150 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    1.491    0.012 threading.py:556(wait)
+      100    0.001    0.000    1.490    0.015 _base.py:201(as_completed)
+      110    0.000    0.000    0.713    0.006 _base.py:417(result)
+       30    0.000    0.000    0.713    0.024 _base.py:601(result_iterator)
+      110    0.001    0.000    0.009    0.000 thread.py:155(submit)
+       10    0.003    0.000    0.008    0.001 coef.py:186(<dictcomp>)
       110    0.000    0.000    0.007    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.004    0.000 threading.py:873(start)
+       30    0.000    0.000    0.005    0.000 threading.py:873(start)
        10    0.000    0.000    0.004    0.000 _base.py:572(map)
        10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
        10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_100.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_100.txt
@@ -1,26 +1,26 @@
-         9362 function calls (9352 primitive calls) in 0.355 seconds
+         9146 function calls (9136 primitive calls) in 0.359 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.355    0.355 {built-in method builtins.exec}
-        1    0.000    0.000    0.355    0.355 <string>:1(<module>)
-        1    0.000    0.000    0.355    0.355 1517976664.py:1(func)
-       10    0.001    0.000    0.355    0.035 coef.py:252(cm)
-       10    0.000    0.000    0.329    0.033 coef.py:387(compute_coef)
-       10    0.000    0.000    0.328    0.033 coef.py:380(cdist_func)
-       10    0.040    0.004    0.328    0.033 coef.py:168(cdist_parts_parallel)
-      792    0.303    0.000    0.303    0.000 {method 'acquire' of '_thread.lock' objects}
-      197    0.001    0.000    0.303    0.002 threading.py:280(wait)
-      104    0.000    0.000    0.286    0.003 threading.py:556(wait)
-      100    0.001    0.000    0.278    0.003 _base.py:201(as_completed)
-      110    0.000    0.000    0.018    0.000 _base.py:417(result)
-       30    0.000    0.000    0.018    0.001 _base.py:601(result_iterator)
-      110    0.000    0.000    0.013    0.000 thread.py:155(submit)
-      110    0.000    0.000    0.012    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.010    0.000 threading.py:873(start)
-       10    0.001    0.000    0.010    0.001 coef.py:178(<dictcomp>)
-       10    0.000    0.000    0.004    0.000 _base.py:572(map)
-       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
+        1    0.000    0.000    0.359    0.359 {built-in method builtins.exec}
+        1    0.000    0.000    0.359    0.359 <string>:1(<module>)
+        1    0.000    0.000    0.359    0.359 1517976664.py:1(func)
+       10    0.001    0.000    0.359    0.036 coef.py:275(cm)
+       10    0.000    0.000    0.331    0.033 coef.py:414(compute_coef)
+       10    0.000    0.000    0.330    0.033 coef.py:407(cdist_func)
+       10    0.050    0.005    0.330    0.033 coef.py:168(cdist_parts_parallel)
+      744    0.299    0.000    0.299    0.000 {method 'acquire' of '_thread.lock' objects}
+      184    0.001    0.000    0.298    0.002 threading.py:280(wait)
+       98    0.000    0.000    0.284    0.003 threading.py:556(wait)
+      100    0.001    0.000    0.270    0.003 _base.py:201(as_completed)
+      110    0.000    0.000    0.020    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.019    0.000 thread.py:174(_adjust_thread_count)
+       30    0.000    0.000    0.017    0.001 threading.py:873(start)
+      110    0.000    0.000    0.014    0.000 _base.py:417(result)
+       30    0.000    0.000    0.014    0.000 _base.py:601(result_iterator)
+       10    0.000    0.000    0.010    0.001 _base.py:572(map)
+       10    0.000    0.000    0.010    0.001 _base.py:597(<listcomp>)
+       10    0.000    0.000    0.010    0.001 coef.py:186(<dictcomp>)
        10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_1000.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_1000.txt
@@ -1,26 +1,26 @@
-         9862 function calls (9852 primitive calls) in 0.859 seconds
+         9875 function calls (9865 primitive calls) in 0.867 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.859    0.859 {built-in method builtins.exec}
-        1    0.000    0.000    0.859    0.859 <string>:1(<module>)
-        1    0.000    0.000    0.859    0.859 1517976664.py:1(func)
-       10    0.001    0.000    0.859    0.086 coef.py:252(cm)
-      226    0.001    0.000    0.836    0.004 threading.py:280(wait)
-      900    0.835    0.001    0.835    0.001 {method 'acquire' of '_thread.lock' objects}
-       10    0.000    0.000    0.826    0.083 coef.py:387(compute_coef)
-       10    0.000    0.000    0.825    0.083 coef.py:380(cdist_func)
-       10    0.010    0.001    0.825    0.082 coef.py:168(cdist_parts_parallel)
-      119    0.000    0.000    0.812    0.007 threading.py:556(wait)
-      100    0.001    0.000    0.807    0.008 _base.py:201(as_completed)
-      110    0.000    0.000    0.024    0.000 _base.py:417(result)
-       30    0.000    0.000    0.024    0.001 _base.py:601(result_iterator)
-      110    0.001    0.000    0.011    0.000 thread.py:155(submit)
-      110    0.000    0.000    0.010    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.007    0.000 threading.py:873(start)
-       10    0.001    0.000    0.007    0.001 coef.py:178(<dictcomp>)
-       10    0.000    0.000    0.005    0.001 _base.py:572(map)
-       10    0.000    0.000    0.005    0.001 _base.py:597(<listcomp>)
+        1    0.000    0.000    0.867    0.867 {built-in method builtins.exec}
+        1    0.000    0.000    0.867    0.867 <string>:1(<module>)
+        1    0.000    0.000    0.867    0.867 1517976664.py:1(func)
+       10    0.001    0.000    0.866    0.087 coef.py:275(cm)
+      226    0.001    0.000    0.845    0.004 threading.py:280(wait)
+      902    0.845    0.001    0.845    0.001 {method 'acquire' of '_thread.lock' objects}
+       10    0.000    0.000    0.831    0.083 coef.py:414(compute_coef)
+       10    0.000    0.000    0.830    0.083 coef.py:407(cdist_func)
+       10    0.007    0.001    0.830    0.083 coef.py:168(cdist_parts_parallel)
+      120    0.000    0.000    0.818    0.007 threading.py:556(wait)
+      100    0.001    0.000    0.815    0.008 _base.py:201(as_completed)
+      110    0.000    0.000    0.028    0.000 _base.py:417(result)
+       30    0.000    0.000    0.027    0.001 _base.py:601(result_iterator)
+      110    0.001    0.000    0.009    0.000 thread.py:155(submit)
+      110    0.001    0.000    0.008    0.000 thread.py:174(_adjust_thread_count)
+       10    0.002    0.000    0.007    0.001 coef.py:186(<dictcomp>)
+       30    0.000    0.000    0.006    0.000 threading.py:873(start)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
        10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_50.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_50.txt
@@ -1,26 +1,26 @@
-         7219 function calls (7209 primitive calls) in 0.122 seconds
+         7071 function calls (7061 primitive calls) in 0.123 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.122    0.122 {built-in method builtins.exec}
-        1    0.000    0.000    0.122    0.122 <string>:1(<module>)
-        1    0.000    0.000    0.122    0.122 1517976664.py:1(func)
-       10    0.001    0.000    0.122    0.012 coef.py:252(cm)
-       10    0.000    0.000    0.104    0.010 coef.py:387(compute_coef)
-       10    0.000    0.000    0.103    0.010 coef.py:380(cdist_func)
-       10    0.018    0.002    0.103    0.010 coef.py:168(cdist_parts_parallel)
-      137    0.000    0.000    0.096    0.001 threading.py:280(wait)
-      558    0.096    0.000    0.096    0.000 {method 'acquire' of '_thread.lock' objects}
-       77    0.000    0.000    0.091    0.001 threading.py:556(wait)
-       70    0.000    0.000    0.077    0.001 _base.py:201(as_completed)
-       80    0.000    0.000    0.019    0.000 thread.py:155(submit)
-       80    0.000    0.000    0.018    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.016    0.001 threading.py:873(start)
-       10    0.000    0.000    0.011    0.001 _base.py:572(map)
-       10    0.000    0.000    0.011    0.001 _base.py:597(<listcomp>)
-       10    0.001    0.000    0.008    0.001 coef.py:178(<dictcomp>)
-       80    0.000    0.000    0.005    0.000 _base.py:417(result)
+        1    0.000    0.000    0.123    0.123 {built-in method builtins.exec}
+        1    0.000    0.000    0.123    0.123 <string>:1(<module>)
+        1    0.000    0.000    0.123    0.123 1517976664.py:1(func)
+       10    0.001    0.000    0.123    0.012 coef.py:275(cm)
+       10    0.000    0.000    0.103    0.010 coef.py:414(compute_coef)
+       10    0.000    0.000    0.102    0.010 coef.py:407(cdist_func)
+       10    0.015    0.002    0.102    0.010 coef.py:168(cdist_parts_parallel)
+      131    0.000    0.000    0.099    0.001 threading.py:280(wait)
+      534    0.099    0.000    0.099    0.000 {method 'acquire' of '_thread.lock' objects}
+       72    0.000    0.000    0.095    0.001 threading.py:556(wait)
+       70    0.000    0.000    0.074    0.001 _base.py:201(as_completed)
+       80    0.000    0.000    0.025    0.000 thread.py:155(submit)
+       80    0.000    0.000    0.024    0.000 thread.py:174(_adjust_thread_count)
+       30    0.000    0.000    0.023    0.001 threading.py:873(start)
+       10    0.000    0.000    0.013    0.001 coef.py:186(<dictcomp>)
+       10    0.000    0.000    0.013    0.001 _base.py:572(map)
+       10    0.000    0.000    0.013    0.001 _base.py:597(<listcomp>)
+       80    0.000    0.000    0.004    0.000 _base.py:417(result)
        30    0.000    0.000    0.004    0.000 _base.py:601(result_iterator)
        10    0.000    0.000    0.001    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_500.txt
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/10-n_samples_small_500.txt
@@ -1,26 +1,26 @@
-         9612 function calls (9602 primitive calls) in 0.477 seconds
+         9462 function calls (9452 primitive calls) in 0.392 seconds
 
    Ordered by: cumulative time
    List reduced from 131 to 20 due to restriction <20>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.477    0.477 {built-in method builtins.exec}
-        1    0.000    0.000    0.477    0.477 <string>:1(<module>)
-        1    0.000    0.000    0.477    0.477 1517976664.py:1(func)
-       10    0.001    0.000    0.477    0.048 coef.py:252(cm)
-       10    0.000    0.000    0.443    0.044 coef.py:387(compute_coef)
-       10    0.000    0.000    0.442    0.044 coef.py:380(cdist_func)
-       10    0.053    0.005    0.442    0.044 coef.py:168(cdist_parts_parallel)
-      209    0.001    0.000    0.410    0.002 threading.py:280(wait)
-      840    0.410    0.000    0.410    0.000 {method 'acquire' of '_thread.lock' objects}
-      113    0.000    0.000    0.389    0.003 threading.py:556(wait)
-      100    0.001    0.000    0.381    0.004 _base.py:201(as_completed)
-      110    0.000    0.000    0.022    0.000 _base.py:417(result)
-       30    0.000    0.000    0.022    0.001 _base.py:601(result_iterator)
-      110    0.000    0.000    0.014    0.000 thread.py:155(submit)
-      110    0.000    0.000    0.013    0.000 thread.py:174(_adjust_thread_count)
-       30    0.000    0.000    0.011    0.000 threading.py:873(start)
-       10    0.000    0.000    0.008    0.001 _base.py:572(map)
-       10    0.000    0.000    0.008    0.001 _base.py:597(<listcomp>)
-       10    0.002    0.000    0.008    0.001 coef.py:178(<dictcomp>)
+        1    0.000    0.000    0.392    0.392 {built-in method builtins.exec}
+        1    0.000    0.000    0.392    0.392 <string>:1(<module>)
+        1    0.000    0.000    0.392    0.392 1517976664.py:1(func)
+       10    0.001    0.000    0.392    0.039 coef.py:275(cm)
+       10    0.000    0.000    0.363    0.036 coef.py:414(compute_coef)
+       10    0.000    0.000    0.362    0.036 coef.py:407(cdist_func)
+       10    0.043    0.004    0.362    0.036 coef.py:168(cdist_parts_parallel)
+      201    0.001    0.000    0.338    0.002 threading.py:280(wait)
+      810    0.338    0.000    0.338    0.000 {method 'acquire' of '_thread.lock' objects}
+      108    0.000    0.000    0.317    0.003 threading.py:556(wait)
+      100    0.001    0.000    0.312    0.003 _base.py:201(as_completed)
+      110    0.000    0.000    0.021    0.000 _base.py:417(result)
+       30    0.000    0.000    0.021    0.001 _base.py:601(result_iterator)
+      110    0.000    0.000    0.011    0.000 thread.py:155(submit)
+      110    0.000    0.000    0.010    0.000 thread.py:174(_adjust_thread_count)
+       30    0.000    0.000    0.008    0.000 threading.py:873(start)
+       10    0.001    0.000    0.007    0.001 coef.py:186(<dictcomp>)
+       10    0.000    0.000    0.004    0.000 _base.py:572(map)
+       10    0.000    0.000    0.004    0.000 _base.py:597(<listcomp>)
        10    0.000    0.000    0.002    0.000 _base.py:635(__exit__)

--- a/nbs/others/05_clustermatch_profiling/10_cm_optimized/py/10-cdist_parts_v04.py
+++ b/nbs/others/05_clustermatch_profiling/10_cm_optimized/py/10-cdist_parts_v04.py
@@ -167,7 +167,7 @@ func()
 # %%prun -s cumulative -l 20 -T 10-n_samples_small_1000.txt
 func()
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # **CONCLUSION:** as expected, with relatively small samples, the numba-compiled version (`09-cdist_parts_v04`) performs much better than the non-compiled one.
 
 # %% [markdown] tags=[]
@@ -223,7 +223,7 @@ func()
 # %%prun -s cumulative -l 20 -T 10-n_samples_large_100000.txt
 func()
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # **CONCLUSION:** this is unexpected. With very large samples, the python version performs better! Something to look at in the future. The profiling file for 100,000 samples () shows that the `cdist_parts_parallel` is taking more time in the numba-compiled version than in the python version. Maybe the compiled ARI implementation could be improved in these cases with large samples.
 
 # %% tags=[]

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/06-cm_many_genes.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/06-cm_many_genes.txt
@@ -1,17 +1,17 @@
-         1029 function calls (1023 primitive calls) in 432.745 seconds
+         1021 function calls (1015 primitive calls) in 432.044 seconds
 
    Ordered by: cumulative time
    List reduced from 133 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000  432.745  432.745 {built-in method builtins.exec}
-        1    0.000    0.000  432.745  432.745 <string>:1(<module>)
-        1    0.000    0.000  432.745  432.745 1750096170.py:1(func)
-        1    0.012    0.012  432.745  432.745 coef.py:252(cm)
-       27    0.000    0.000  432.731   16.027 threading.py:280(wait)
-       81  432.731    5.342  432.731    5.342 {method 'acquire' of '_thread.lock' objects}
-       20    0.000    0.000  432.731   21.637 _base.py:601(result_iterator)
-       18    0.000    0.000  432.731   24.041 _base.py:417(result)
+        1    0.000    0.000  432.044  432.044 {built-in method builtins.exec}
+        1    0.000    0.000  432.044  432.044 <string>:1(<module>)
+        1    0.000    0.000  432.044  432.044 1750096170.py:1(func)
+        1    0.005    0.005  432.044  432.044 coef.py:275(cm)
+       26    0.000    0.000  432.037   16.617 threading.py:280(wait)
+       79  432.037    5.469  432.037    5.469 {method 'acquire' of '_thread.lock' objects}
+       20    0.000    0.000  432.037   21.602 _base.py:601(result_iterator)
+       18    0.000    0.000  432.036   24.002 _base.py:417(result)
         2    0.000    0.000    0.001    0.000 _base.py:572(map)
         2    0.000    0.000    0.001    0.000 _base.py:597(<listcomp>)
        18    0.000    0.000    0.001    0.000 thread.py:155(submit)
@@ -19,38 +19,38 @@
         2    0.001    0.000    0.001    0.000 {built-in method numpy.zeros}
         3    0.000    0.000    0.000    0.000 threading.py:873(start)
         3    0.000    0.000    0.000    0.000 threading.py:556(wait)
+        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
+        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
+        1    0.000    0.000    0.000    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
         3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
-        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
         9    0.000    0.000    0.000    0.000 typedlist.py:341(append)
-        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
-        1    0.000    0.000    0.000    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
-        2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
-       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
+        2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
         1    0.000    0.000    0.000    0.000 typedlist.py:298(_initialise_list)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
+       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
         3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
-        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
-       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
        18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
        22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
-        2    0.000    0.000    0.000    0.000 typeof.py:25(typeof)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
+        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
         2    0.000    0.000    0.000    0.000 abstract.py:60(__call__)
-        2    0.000    0.000    0.000    0.000 functools.py:872(wrapper)
+        2    0.000    0.000    0.000    0.000 typeof.py:25(typeof)
        39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+        2    0.000    0.000    0.000    0.000 functools.py:872(wrapper)
         1    0.000    0.000    0.000    0.000 typedlist.py:270(_parse_arg)
-       15    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
-        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
-        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
-        1    0.000    0.000    0.000    0.000 dispatcher.py:677(typeof_pyval)
-        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
+       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
         2    0.000    0.000    0.000    0.000 abstract.py:48(_intern)
-       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
-        1    0.000    0.000    0.000    0.000 threading.py:398(__init__)
-        3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
+        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
         2    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+        1    0.000    0.000    0.000    0.000 dispatcher.py:677(typeof_pyval)
+        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
+       14    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+       18    0.000    0.000    0.000    0.000 _base.py:387(__get_result)
+       12    0.000    0.000    0.000    0.000 threading.py:268(_acquire_restore)
         1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+    12/10    0.000    0.000    0.000    0.000 abstract.py:120(__eq__)
         1    0.000    0.000    0.000    0.000 typeof.py:257(_typeof_nb_type)
-        1    0.000    0.000    0.000    0.000 typeof.py:121(_typeof_int)
+        1    0.000    0.000    0.000    0.000 typedlist.py:228(__init__)
+        1    0.000    0.000    0.000    0.000 containers.py:618(__init__)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/06-many_genes.ipynb
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/06-many_genes.ipynb
@@ -5,10 +5,10 @@
    "id": "507e9319-381b-4934-987c-2958e7f6ace7",
    "metadata": {
     "papermill": {
-     "duration": 0.072169,
-     "end_time": "2021-11-28T04:51:26.725158",
+     "duration": 0.063067,
+     "end_time": "2021-12-02T04:54:41.010848",
      "exception": false,
-     "start_time": "2021-11-28T04:51:26.652989",
+     "start_time": "2021-12-02T04:54:40.947781",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "9a88f2a7-3773-459c-8fdc-c69c1b0bb338",
    "metadata": {
     "papermill": {
-     "duration": 0.03548,
-     "end_time": "2021-11-28T04:51:26.800572",
+     "duration": 0.036602,
+     "end_time": "2021-12-02T04:54:41.090292",
      "exception": false,
-     "start_time": "2021-11-28T04:51:26.765092",
+     "start_time": "2021-12-02T04:54:41.053690",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "72de9f6f-dc00-435e-9dba-871db859a78a",
    "metadata": {
     "papermill": {
-     "duration": 0.034371,
-     "end_time": "2021-11-28T04:51:26.869321",
+     "duration": 0.034206,
+     "end_time": "2021-12-02T04:54:41.159443",
      "exception": false,
-     "start_time": "2021-11-28T04:51:26.834950",
+     "start_time": "2021-12-02T04:54:41.125237",
      "status": "completed"
     },
     "tags": []
@@ -57,16 +57,16 @@
    "id": "88d32361-f1b5-4cf0-9a2c-7ab927d14b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:26.943646Z",
-     "iopub.status.busy": "2021-11-28T04:51:26.943199Z",
-     "iopub.status.idle": "2021-11-28T04:51:27.530471Z",
-     "shell.execute_reply": "2021-11-28T04:51:27.528615Z"
+     "iopub.execute_input": "2021-12-02T04:54:41.233768Z",
+     "iopub.status.busy": "2021-12-02T04:54:41.233319Z",
+     "iopub.status.idle": "2021-12-02T04:54:41.818757Z",
+     "shell.execute_reply": "2021-12-02T04:54:41.820228Z"
     },
     "papermill": {
-     "duration": 0.627876,
-     "end_time": "2021-11-28T04:51:27.530872",
+     "duration": 0.627925,
+     "end_time": "2021-12-02T04:54:41.820912",
      "exception": false,
-     "start_time": "2021-11-28T04:51:26.902996",
+     "start_time": "2021-12-02T04:54:41.192987",
      "status": "completed"
     },
     "tags": []
@@ -90,16 +90,16 @@
    "id": "8a27da6e-cf59-4276-888b-57e98fd23ccf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:27.608286Z",
-     "iopub.status.busy": "2021-11-28T04:51:27.606347Z",
-     "iopub.status.idle": "2021-11-28T04:51:28.216451Z",
-     "shell.execute_reply": "2021-11-28T04:51:28.214501Z"
+     "iopub.execute_input": "2021-12-02T04:54:41.895697Z",
+     "iopub.status.busy": "2021-12-02T04:54:41.895221Z",
+     "iopub.status.idle": "2021-12-02T04:54:42.493909Z",
+     "shell.execute_reply": "2021-12-02T04:54:42.495705Z"
     },
     "papermill": {
-     "duration": 0.650499,
-     "end_time": "2021-11-28T04:51:28.216817",
+     "duration": 0.639895,
+     "end_time": "2021-12-02T04:54:42.496180",
      "exception": false,
-     "start_time": "2021-11-28T04:51:27.566318",
+     "start_time": "2021-12-02T04:54:41.856285",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "561480f7-c610-4f60-b40f-8100974ab4d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:28.324963Z",
-     "iopub.status.busy": "2021-11-28T04:51:28.324481Z",
-     "iopub.status.idle": "2021-11-28T04:51:28.936497Z",
-     "shell.execute_reply": "2021-11-28T04:51:28.934597Z"
+     "iopub.execute_input": "2021-12-02T04:54:42.607578Z",
+     "iopub.status.busy": "2021-12-02T04:54:42.604517Z",
+     "iopub.status.idle": "2021-12-02T04:54:43.225394Z",
+     "shell.execute_reply": "2021-12-02T04:54:43.223462Z"
     },
     "papermill": {
-     "duration": 0.651989,
-     "end_time": "2021-11-28T04:51:28.936865",
+     "duration": 0.66041,
+     "end_time": "2021-12-02T04:54:43.225770",
      "exception": false,
-     "start_time": "2021-11-28T04:51:28.284876",
+     "start_time": "2021-12-02T04:54:42.565360",
      "status": "completed"
     },
     "tags": []
@@ -162,16 +162,16 @@
    "id": "a5c90a17-c0ac-49f0-968d-ea9ea8710b00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:29.047877Z",
-     "iopub.status.busy": "2021-11-28T04:51:29.044962Z",
-     "iopub.status.idle": "2021-11-28T04:51:29.645316Z",
-     "shell.execute_reply": "2021-11-28T04:51:29.646846Z"
+     "iopub.execute_input": "2021-12-02T04:54:43.339179Z",
+     "iopub.status.busy": "2021-12-02T04:54:43.336569Z",
+     "iopub.status.idle": "2021-12-02T04:54:43.946905Z",
+     "shell.execute_reply": "2021-12-02T04:54:43.945347Z"
     },
     "papermill": {
-     "duration": 0.64137,
-     "end_time": "2021-11-28T04:51:29.647281",
+     "duration": 0.650877,
+     "end_time": "2021-12-02T04:54:43.947295",
      "exception": false,
-     "start_time": "2021-11-28T04:51:29.005911",
+     "start_time": "2021-12-02T04:54:43.296418",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "145563a2-3e46-4f62-8191-7444a0b315bb",
    "metadata": {
     "papermill": {
-     "duration": 0.034994,
-     "end_time": "2021-11-28T04:51:29.723376",
+     "duration": 0.035542,
+     "end_time": "2021-12-02T04:54:44.052030",
      "exception": false,
-     "start_time": "2021-11-28T04:51:29.688382",
+     "start_time": "2021-12-02T04:54:44.016488",
      "status": "completed"
     },
     "tags": []
@@ -204,16 +204,16 @@
    "id": "bea3d48e-8823-403f-90f5-aea8a17b357c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:29.808584Z",
-     "iopub.status.busy": "2021-11-28T04:51:29.808125Z",
-     "iopub.status.idle": "2021-11-28T04:51:30.129956Z",
-     "shell.execute_reply": "2021-11-28T04:51:30.130326Z"
+     "iopub.execute_input": "2021-12-02T04:54:44.129271Z",
+     "iopub.status.busy": "2021-12-02T04:54:44.128813Z",
+     "iopub.status.idle": "2021-12-02T04:54:44.450031Z",
+     "shell.execute_reply": "2021-12-02T04:54:44.450369Z"
     },
     "papermill": {
-     "duration": 0.366234,
-     "end_time": "2021-11-28T04:51:30.130444",
+     "duration": 0.362043,
+     "end_time": "2021-12-02T04:54:44.450488",
      "exception": false,
-     "start_time": "2021-11-28T04:51:29.764210",
+     "start_time": "2021-12-02T04:54:44.088445",
      "status": "completed"
     },
     "tags": []
@@ -231,16 +231,16 @@
    "id": "df6b3793-930b-4c54-9f29-ecc47fc586fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:30.207387Z",
-     "iopub.status.busy": "2021-11-28T04:51:30.206931Z",
-     "iopub.status.idle": "2021-11-28T04:51:38.882809Z",
-     "shell.execute_reply": "2021-11-28T04:51:38.882339Z"
+     "iopub.execute_input": "2021-12-02T04:54:44.526698Z",
+     "iopub.status.busy": "2021-12-02T04:54:44.526251Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.246338Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.245882Z"
     },
     "papermill": {
-     "duration": 8.716013,
-     "end_time": "2021-11-28T04:51:38.882905",
+     "duration": 8.759411,
+     "end_time": "2021-12-02T04:54:53.246436",
      "exception": false,
-     "start_time": "2021-11-28T04:51:30.166892",
+     "start_time": "2021-12-02T04:54:44.487025",
      "status": "completed"
     },
     "tags": []
@@ -249,7 +249,7 @@
     {
      "data": {
       "text/plain": [
-       "0.15625"
+       "0.28"
       ]
      },
      "execution_count": 6,
@@ -267,10 +267,10 @@
    "id": "f8399ca8-265e-4e96-b582-54045cb2f9eb",
    "metadata": {
     "papermill": {
-     "duration": 0.036539,
-     "end_time": "2021-11-28T04:51:38.956934",
+     "duration": 0.036734,
+     "end_time": "2021-12-02T04:54:53.320954",
      "exception": false,
-     "start_time": "2021-11-28T04:51:38.920395",
+     "start_time": "2021-12-02T04:54:53.284220",
      "status": "completed"
     },
     "tags": []
@@ -285,16 +285,16 @@
    "id": "2316ffcd-a6e4-453f-bb52-779685c5c5bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.033822Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.033364Z",
-     "iopub.status.idle": "2021-11-28T04:51:39.035244Z",
-     "shell.execute_reply": "2021-11-28T04:51:39.034856Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.397945Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.397500Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.399405Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.399043Z"
     },
     "papermill": {
-     "duration": 0.041579,
-     "end_time": "2021-11-28T04:51:39.035336",
+     "duration": 0.041941,
+     "end_time": "2021-12-02T04:54:53.399500",
      "exception": false,
-     "start_time": "2021-11-28T04:51:38.993757",
+     "start_time": "2021-12-02T04:54:53.357559",
      "status": "completed"
     },
     "tags": []
@@ -310,16 +310,16 @@
    "id": "b2f92fb1-113d-479b-8bbf-2be229e26e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.112308Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.111751Z",
-     "iopub.status.idle": "2021-11-28T04:51:39.114210Z",
-     "shell.execute_reply": "2021-11-28T04:51:39.113743Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.478422Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.477956Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.479712Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.480117Z"
     },
     "papermill": {
-     "duration": 0.042368,
-     "end_time": "2021-11-28T04:51:39.114304",
+     "duration": 0.042417,
+     "end_time": "2021-12-02T04:54:53.480228",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.071936",
+     "start_time": "2021-12-02T04:54:53.437811",
      "status": "completed"
     },
     "tags": []
@@ -335,16 +335,16 @@
    "id": "63638c0b-b436-48a9-93e0-db2adb939a61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.192151Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.191642Z",
-     "iopub.status.idle": "2021-11-28T04:51:39.198362Z",
-     "shell.execute_reply": "2021-11-28T04:51:39.197916Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.556736Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.556298Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.562780Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.562412Z"
     },
     "papermill": {
-     "duration": 0.046167,
-     "end_time": "2021-11-28T04:51:39.198454",
+     "duration": 0.045565,
+     "end_time": "2021-12-02T04:54:53.562878",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.152287",
+     "start_time": "2021-12-02T04:54:53.517313",
      "status": "completed"
     },
     "tags": []
@@ -360,16 +360,16 @@
    "id": "808017ed-9a8a-4bf7-a3dd-42317a39ce8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.283951Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.283427Z",
-     "iopub.status.idle": "2021-11-28T04:51:39.286203Z",
-     "shell.execute_reply": "2021-11-28T04:51:39.285810Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.641052Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.640577Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.642681Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.643043Z"
     },
     "papermill": {
-     "duration": 0.048389,
-     "end_time": "2021-11-28T04:51:39.286297",
+     "duration": 0.042734,
+     "end_time": "2021-12-02T04:54:53.643156",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.237908",
+     "start_time": "2021-12-02T04:54:53.600422",
      "status": "completed"
     },
     "tags": []
@@ -395,10 +395,10 @@
    "id": "716e4219-cad5-453b-8331-47d310689e03",
    "metadata": {
     "papermill": {
-     "duration": 0.037235,
-     "end_time": "2021-11-28T04:51:39.362096",
+     "duration": 0.037638,
+     "end_time": "2021-12-02T04:54:53.718878",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.324861",
+     "start_time": "2021-12-02T04:54:53.681240",
      "status": "completed"
     },
     "tags": []
@@ -413,16 +413,16 @@
    "id": "67807856-f337-4c6e-ae31-cd306577a314",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.440469Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.440019Z",
-     "iopub.status.idle": "2021-11-28T04:51:39.441866Z",
-     "shell.execute_reply": "2021-11-28T04:51:39.441420Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.798185Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.797741Z",
+     "iopub.status.idle": "2021-12-02T04:54:53.800101Z",
+     "shell.execute_reply": "2021-12-02T04:54:53.799590Z"
     },
     "papermill": {
-     "duration": 0.042541,
-     "end_time": "2021-11-28T04:51:39.441959",
+     "duration": 0.043428,
+     "end_time": "2021-12-02T04:54:53.800192",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.399418",
+     "start_time": "2021-12-02T04:54:53.756764",
      "status": "completed"
     },
     "tags": []
@@ -440,16 +440,16 @@
    "id": "2965a695-5c0c-4e9e-8435-dcbfa610eb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T04:51:39.530377Z",
-     "iopub.status.busy": "2021-11-28T04:51:39.524492Z",
-     "iopub.status.idle": "2021-11-28T06:48:12.100577Z",
-     "shell.execute_reply": "2021-11-28T06:48:12.101038Z"
+     "iopub.execute_input": "2021-12-02T04:54:53.883448Z",
+     "iopub.status.busy": "2021-12-02T04:54:53.882988Z",
+     "iopub.status.idle": "2021-12-02T06:51:58.467071Z",
+     "shell.execute_reply": "2021-12-02T06:51:58.467426Z"
     },
     "papermill": {
-     "duration": 6992.620944,
-     "end_time": "2021-11-28T06:48:12.101212",
+     "duration": 7024.629209,
+     "end_time": "2021-12-02T06:51:58.467540",
      "exception": false,
-     "start_time": "2021-11-28T04:51:39.480268",
+     "start_time": "2021-12-02T04:54:53.838331",
      "status": "completed"
     },
     "tags": []
@@ -459,7 +459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7min 17s ± 3.39 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "7min 19s ± 3.38 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -474,16 +474,16 @@
    "id": "51c7a416-064a-4669-a09f-16f837d32475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:48:12.183223Z",
-     "iopub.status.busy": "2021-11-28T06:48:12.182738Z",
-     "iopub.status.idle": "2021-11-28T06:55:24.970743Z",
-     "shell.execute_reply": "2021-11-28T06:55:24.971116Z"
+     "iopub.execute_input": "2021-12-02T06:51:59.424926Z",
+     "iopub.status.busy": "2021-12-02T06:51:59.424446Z",
+     "iopub.status.idle": "2021-12-02T06:59:11.510778Z",
+     "shell.execute_reply": "2021-12-02T06:59:11.511146Z"
     },
     "papermill": {
-     "duration": 432.830901,
-     "end_time": "2021-11-28T06:55:24.971228",
+     "duration": 432.133084,
+     "end_time": "2021-12-02T06:59:11.511260",
      "exception": false,
-     "start_time": "2021-11-28T06:48:12.140327",
+     "start_time": "2021-12-02T06:51:59.378176",
      "status": "completed"
     },
     "tags": []
@@ -509,10 +509,10 @@
    "id": "e2556204-1c10-4e01-8c6c-ea63ddb37530",
    "metadata": {
     "papermill": {
-     "duration": 0.039069,
-     "end_time": "2021-11-28T06:55:25.049276",
+     "duration": 0.04535,
+     "end_time": "2021-12-02T06:59:12.473542",
      "exception": false,
-     "start_time": "2021-11-28T06:55:25.010207",
+     "start_time": "2021-12-02T06:59:12.428192",
      "status": "completed"
     },
     "tags": []
@@ -544,14 +544,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7440.076655,
-   "end_time": "2021-11-28T06:55:25.509202",
+   "duration": 7473.205113,
+   "end_time": "2021-12-02T06:59:12.931915",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/06-many_genes.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/06-many_genes.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T04:51:25.432547",
+   "start_time": "2021-12-02T04:54:39.726802",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-cm_many_samples-default_internal_n_clusters.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-cm_many_samples-default_internal_n_clusters.txt
@@ -1,56 +1,56 @@
-         1069 function calls (1059 primitive calls) in 3.931 seconds
+         1077 function calls (1067 primitive calls) in 3.943 seconds
 
    Ordered by: cumulative time
    List reduced from 134 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    3.931    3.931 {built-in method builtins.exec}
-        1    0.000    0.000    3.931    3.931 <string>:1(<module>)
-        1    0.000    0.000    3.931    3.931 1750096170.py:1(func)
-        1    0.001    0.001    3.931    3.931 coef.py:252(cm)
-       25    0.000    0.000    3.928    0.157 threading.py:280(wait)
-       20    0.000    0.000    3.928    0.196 _base.py:601(result_iterator)
-       18    0.000    0.000    3.928    0.218 _base.py:417(result)
-       77    3.928    0.051    3.928    0.051 {method 'acquire' of '_thread.lock' objects}
+        1    0.000    0.000    3.943    3.943 {built-in method builtins.exec}
+        1    0.000    0.000    3.943    3.943 <string>:1(<module>)
+        1    0.000    0.000    3.943    3.943 1750096170.py:1(func)
+        1    0.001    0.001    3.943    3.943 coef.py:275(cm)
+       20    0.000    0.000    3.940    0.197 _base.py:601(result_iterator)
+       26    0.000    0.000    3.940    0.152 threading.py:280(wait)
+       18    0.000    0.000    3.940    0.219 _base.py:417(result)
+       79    3.940    0.050    3.940    0.050 {method 'acquire' of '_thread.lock' objects}
         2    0.000    0.000    0.001    0.000 _base.py:572(map)
         2    0.000    0.000    0.001    0.000 _base.py:597(<listcomp>)
        18    0.000    0.000    0.001    0.000 thread.py:155(submit)
        18    0.000    0.000    0.001    0.000 thread.py:174(_adjust_thread_count)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
         3    0.000    0.000    0.000    0.000 threading.py:873(start)
         3    0.000    0.000    0.000    0.000 threading.py:556(wait)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
-        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
+        9    0.000    0.000    0.000    0.000 typedlist.py:341(append)
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
-        9    0.000    0.000    0.000    0.000 typedlist.py:341(append)
-        3    0.000    0.000    0.000    0.000 threading.py:1021(join)
-        3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
        18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
+        3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         1    0.000    0.000    0.000    0.000 typedlist.py:298(_initialise_list)
-      6/2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
-        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
-       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
+        3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
+      6/2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
        18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
        22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
-        2    0.000    0.000    0.000    0.000 abstract.py:60(__call__)
+        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
         2    0.000    0.000    0.000    0.000 typeof.py:25(typeof)
-        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
-        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
+        2    0.000    0.000    0.000    0.000 abstract.py:60(__call__)
+       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
         2    0.000    0.000    0.000    0.000 functools.py:872(wrapper)
-       13    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
-       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
         1    0.000    0.000    0.000    0.000 typedlist.py:270(_parse_arg)
+        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
         1    0.000    0.000    0.000    0.000 numeric.py:289(full)
+       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
         1    0.000    0.000    0.000    0.000 dispatcher.py:677(typeof_pyval)
         2    0.000    0.000    0.000    0.000 abstract.py:48(_intern)
+       18    0.000    0.000    0.000    0.000 thread.py:41(__init__)
         3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
+       31    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
         2    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
-        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
+       14    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
         1    0.000    0.000    0.000    0.000 typeof.py:257(_typeof_nb_type)
-        2    0.000    0.000    0.000    0.000 functools.py:816(dispatch)
+        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+        1    0.000    0.000    0.000    0.000 typeof.py:121(_typeof_int)
         1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
         1    0.000    0.000    0.000    0.000 containers.py:618(__init__)
-        1    0.000    0.000    0.000    0.000 {built-in method numpy.asarray}
-        3    0.000    0.000    0.000    0.000 {method 'difference_update' of 'set' objects}
+        1    0.000    0.000    0.000    0.000 utils.py:294(bit_length)
         3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
-        9    0.000    0.000    0.000    0.000 typedlist.py:81(_append)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-cm_many_samples-less_internal_n_clusters.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-cm_many_samples-less_internal_n_clusters.txt
@@ -1,56 +1,56 @@
-         1039 function calls (1029 primitive calls) in 0.571 seconds
+         1031 function calls (1021 primitive calls) in 0.574 seconds
 
    Ordered by: cumulative time
    List reduced from 134 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.571    0.571 {built-in method builtins.exec}
-        1    0.000    0.000    0.571    0.571 <string>:1(<module>)
-        1    0.000    0.000    0.571    0.571 2695477961.py:1(func)
-        1    0.000    0.000    0.571    0.571 coef.py:252(cm)
-       25    0.000    0.000    0.569    0.023 threading.py:280(wait)
-       77    0.569    0.007    0.569    0.007 {method 'acquire' of '_thread.lock' objects}
-       20    0.000    0.000    0.569    0.028 _base.py:601(result_iterator)
-       18    0.000    0.000    0.569    0.032 _base.py:417(result)
+        1    0.000    0.000    0.574    0.574 {built-in method builtins.exec}
+        1    0.000    0.000    0.574    0.574 <string>:1(<module>)
+        1    0.000    0.000    0.574    0.574 2695477961.py:1(func)
+        1    0.000    0.000    0.574    0.574 coef.py:275(cm)
+       24    0.000    0.000    0.572    0.024 threading.py:280(wait)
+       75    0.572    0.008    0.572    0.008 {method 'acquire' of '_thread.lock' objects}
+       20    0.000    0.000    0.571    0.029 _base.py:601(result_iterator)
+       18    0.000    0.000    0.571    0.032 _base.py:417(result)
         2    0.000    0.000    0.001    0.001 _base.py:572(map)
         2    0.000    0.000    0.001    0.001 _base.py:597(<listcomp>)
        18    0.000    0.000    0.001    0.000 thread.py:155(submit)
        18    0.000    0.000    0.001    0.000 thread.py:174(_adjust_thread_count)
         3    0.000    0.000    0.001    0.000 threading.py:873(start)
         3    0.000    0.000    0.001    0.000 threading.py:556(wait)
-        2    0.001    0.000    0.001    0.000 {built-in method numpy.zeros}
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
+        4    0.000    0.000    0.000    0.000 typedlist.py:341(append)
         3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
-        4    0.000    0.000    0.000    0.000 typedlist.py:341(append)
-      6/2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
         1    0.000    0.000    0.000    0.000 typedlist.py:298(_initialise_list)
        18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
-        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
-        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
+      6/2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
        18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
-       13    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
-       22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
+       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
         2    0.000    0.000    0.000    0.000 typeof.py:25(typeof)
-       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+       22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
         2    0.000    0.000    0.000    0.000 abstract.py:60(__call__)
-        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
         2    0.000    0.000    0.000    0.000 functools.py:872(wrapper)
         1    0.000    0.000    0.000    0.000 typedlist.py:270(_parse_arg)
-       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
-        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
-        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
-       30    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
-        1    0.000    0.000    0.000    0.000 dispatcher.py:677(typeof_pyval)
+        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
+        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
         2    0.000    0.000    0.000    0.000 abstract.py:48(_intern)
-        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
-        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
         2    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
-        6    0.000    0.000    0.000    0.000 utils.py:99(chunker)
+        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
+        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
+        1    0.000    0.000    0.000    0.000 dispatcher.py:677(typeof_pyval)
+       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+       12    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+       28    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
+       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
+        3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
+        2    0.000    0.000    0.000    0.000 functools.py:816(dispatch)
+    12/10    0.000    0.000    0.000    0.000 abstract.py:120(__eq__)
+        1    0.000    0.000    0.000    0.000 typeof.py:257(_typeof_nb_type)
         1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
         1    0.000    0.000    0.000    0.000 typeof.py:121(_typeof_int)
-        1    0.000    0.000    0.000    0.000 typeof.py:257(_typeof_nb_type)
-        1    0.000    0.000    0.000    0.000 typedlist.py:228(__init__)
-       48    0.000    0.000    0.000    0.000 {built-in method builtins.len}
-        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
+        1    0.000    0.000    0.000    0.000 typedlist.py:202(__new__)
+        1    0.000    0.000    0.000    0.000 containers.py:618(__init__)
+        1    0.000    0.000    0.000    0.000 utils.py:294(bit_length)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-many_samples.ipynb
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/07-many_samples.ipynb
@@ -5,10 +5,10 @@
    "id": "fd52facb-2470-4824-83d4-7c9fd042ecfb",
    "metadata": {
     "papermill": {
-     "duration": 0.07918,
-     "end_time": "2021-11-28T06:55:29.146570",
+     "duration": 0.078609,
+     "end_time": "2021-12-02T06:59:16.664384",
      "exception": false,
-     "start_time": "2021-11-28T06:55:29.067390",
+     "start_time": "2021-12-02T06:59:16.585775",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "b95a9893-d5af-400c-9872-dcf70ec874fb",
    "metadata": {
     "papermill": {
-     "duration": 0.040995,
-     "end_time": "2021-11-28T06:55:29.228088",
+     "duration": 0.047112,
+     "end_time": "2021-12-02T06:59:16.751582",
      "exception": false,
-     "start_time": "2021-11-28T06:55:29.187093",
+     "start_time": "2021-12-02T06:59:16.704470",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "325cb06a-df7f-43e8-be3e-f704aaf015b0",
    "metadata": {
     "papermill": {
-     "duration": 0.043057,
-     "end_time": "2021-11-28T06:55:29.312389",
+     "duration": 0.041181,
+     "end_time": "2021-12-02T06:59:16.834168",
      "exception": false,
-     "start_time": "2021-11-28T06:55:29.269332",
+     "start_time": "2021-12-02T06:59:16.792987",
      "status": "completed"
     },
     "tags": []
@@ -57,16 +57,16 @@
    "id": "73f954a6-1776-4b92-bd0e-fc3caf5df081",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:29.400992Z",
-     "iopub.status.busy": "2021-11-28T06:55:29.400529Z",
-     "iopub.status.idle": "2021-11-28T06:55:29.991807Z",
-     "shell.execute_reply": "2021-11-28T06:55:29.989699Z"
+     "iopub.execute_input": "2021-12-02T06:59:16.921167Z",
+     "iopub.status.busy": "2021-12-02T06:59:16.920693Z",
+     "iopub.status.idle": "2021-12-02T06:59:17.506838Z",
+     "shell.execute_reply": "2021-12-02T06:59:17.505077Z"
     },
     "papermill": {
-     "duration": 0.638667,
-     "end_time": "2021-11-28T06:55:29.992243",
+     "duration": 0.633124,
+     "end_time": "2021-12-02T06:59:17.507269",
      "exception": false,
-     "start_time": "2021-11-28T06:55:29.353576",
+     "start_time": "2021-12-02T06:59:16.874145",
      "status": "completed"
     },
     "tags": []
@@ -90,16 +90,16 @@
    "id": "d17492bb-34fe-4c34-a693-419180ba068e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:30.113807Z",
-     "iopub.status.busy": "2021-11-28T06:55:30.113290Z",
-     "iopub.status.idle": "2021-11-28T06:55:30.716862Z",
-     "shell.execute_reply": "2021-11-28T06:55:30.718397Z"
+     "iopub.execute_input": "2021-12-02T06:59:17.595660Z",
+     "iopub.status.busy": "2021-12-02T06:59:17.593712Z",
+     "iopub.status.idle": "2021-12-02T06:59:18.209352Z",
+     "shell.execute_reply": "2021-12-02T06:59:18.207035Z"
     },
     "papermill": {
-     "duration": 0.650842,
-     "end_time": "2021-11-28T06:55:30.718850",
+     "duration": 0.660213,
+     "end_time": "2021-12-02T06:59:18.209740",
      "exception": false,
-     "start_time": "2021-11-28T06:55:30.068008",
+     "start_time": "2021-12-02T06:59:17.549527",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "5683e330-1782-43b3-bb78-255198f03620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:30.840026Z",
-     "iopub.status.busy": "2021-11-28T06:55:30.839528Z",
-     "iopub.status.idle": "2021-11-28T06:55:31.443450Z",
-     "shell.execute_reply": "2021-11-28T06:55:31.441827Z"
+     "iopub.execute_input": "2021-12-02T06:59:18.330716Z",
+     "iopub.status.busy": "2021-12-02T06:59:18.330235Z",
+     "iopub.status.idle": "2021-12-02T06:59:18.939717Z",
+     "shell.execute_reply": "2021-12-02T06:59:18.941520Z"
     },
     "papermill": {
-     "duration": 0.650548,
-     "end_time": "2021-11-28T06:55:31.443834",
+     "duration": 0.657681,
+     "end_time": "2021-12-02T06:59:18.941967",
      "exception": false,
-     "start_time": "2021-11-28T06:55:30.793286",
+     "start_time": "2021-12-02T06:59:18.284286",
      "status": "completed"
     },
     "tags": []
@@ -151,16 +151,16 @@
    "id": "5cf4ce29-d611-4fc8-8880-293c09e5ab9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:31.534296Z",
-     "iopub.status.busy": "2021-11-28T06:55:31.533818Z",
-     "iopub.status.idle": "2021-11-28T06:55:32.132126Z",
-     "shell.execute_reply": "2021-11-28T06:55:32.130214Z"
+     "iopub.execute_input": "2021-12-02T06:59:19.062516Z",
+     "iopub.status.busy": "2021-12-02T06:59:19.060402Z",
+     "iopub.status.idle": "2021-12-02T06:59:19.664542Z",
+     "shell.execute_reply": "2021-12-02T06:59:19.662876Z"
     },
     "papermill": {
-     "duration": 0.644928,
-     "end_time": "2021-11-28T06:55:32.132511",
+     "duration": 0.650322,
+     "end_time": "2021-12-02T06:59:19.664925",
      "exception": false,
-     "start_time": "2021-11-28T06:55:31.487583",
+     "start_time": "2021-12-02T06:59:19.014603",
      "status": "completed"
     },
     "tags": []
@@ -175,10 +175,10 @@
    "id": "35a04385-a901-4726-82a6-a01f16281efe",
    "metadata": {
     "papermill": {
-     "duration": 0.042275,
-     "end_time": "2021-11-28T06:55:32.250590",
+     "duration": 0.048275,
+     "end_time": "2021-12-02T06:59:19.790991",
      "exception": false,
-     "start_time": "2021-11-28T06:55:32.208315",
+     "start_time": "2021-12-02T06:59:19.742716",
      "status": "completed"
     },
     "tags": []
@@ -193,16 +193,16 @@
    "id": "a75c4496-d379-4668-905d-0e9136981f0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:32.340281Z",
-     "iopub.status.busy": "2021-11-28T06:55:32.339798Z",
-     "iopub.status.idle": "2021-11-28T06:55:32.658521Z",
-     "shell.execute_reply": "2021-11-28T06:55:32.658870Z"
+     "iopub.execute_input": "2021-12-02T06:59:19.878688Z",
+     "iopub.status.busy": "2021-12-02T06:59:19.878228Z",
+     "iopub.status.idle": "2021-12-02T06:59:20.199076Z",
+     "shell.execute_reply": "2021-12-02T06:59:20.198611Z"
     },
     "papermill": {
-     "duration": 0.365816,
-     "end_time": "2021-11-28T06:55:32.658994",
+     "duration": 0.366396,
+     "end_time": "2021-12-02T06:59:20.199189",
      "exception": false,
-     "start_time": "2021-11-28T06:55:32.293178",
+     "start_time": "2021-12-02T06:59:19.832793",
      "status": "completed"
     },
     "tags": []
@@ -220,16 +220,16 @@
    "id": "1a58ccf8-1bf5-4177-9b06-944a0d57655a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:32.748675Z",
-     "iopub.status.busy": "2021-11-28T06:55:32.748213Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.268610Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.268159Z"
+     "iopub.execute_input": "2021-12-02T06:59:20.287189Z",
+     "iopub.status.busy": "2021-12-02T06:59:20.286732Z",
+     "iopub.status.idle": "2021-12-02T06:59:28.997990Z",
+     "shell.execute_reply": "2021-12-02T06:59:28.997628Z"
     },
     "papermill": {
-     "duration": 8.566395,
-     "end_time": "2021-11-28T06:55:41.268707",
+     "duration": 8.756092,
+     "end_time": "2021-12-02T06:59:28.998089",
      "exception": false,
-     "start_time": "2021-11-28T06:55:32.702312",
+     "start_time": "2021-12-02T06:59:20.241997",
      "status": "completed"
     },
     "tags": []
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "0.4375"
+       "0.0"
       ]
      },
      "execution_count": 6,
@@ -256,10 +256,10 @@
    "id": "2c92a1ad-2fc9-4a16-a5f8-fce685246996",
    "metadata": {
     "papermill": {
-     "duration": 0.045313,
-     "end_time": "2021-11-28T06:55:41.359660",
+     "duration": 0.041925,
+     "end_time": "2021-12-02T06:59:29.083174",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.314347",
+     "start_time": "2021-12-02T06:59:29.041249",
      "status": "completed"
     },
     "tags": []
@@ -274,16 +274,16 @@
    "id": "2316ffcd-a6e4-453f-bb52-779685c5c5bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:41.452166Z",
-     "iopub.status.busy": "2021-11-28T06:55:41.451663Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.453559Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.453107Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.170685Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.170220Z",
+     "iopub.status.idle": "2021-12-02T06:59:29.171675Z",
+     "shell.execute_reply": "2021-12-02T06:59:29.172043Z"
     },
     "papermill": {
-     "duration": 0.048601,
-     "end_time": "2021-11-28T06:55:41.453655",
+     "duration": 0.046862,
+     "end_time": "2021-12-02T06:59:29.172158",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.405054",
+     "start_time": "2021-12-02T06:59:29.125296",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "b2f92fb1-113d-479b-8bbf-2be229e26e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:41.544599Z",
-     "iopub.status.busy": "2021-11-28T06:55:41.544097Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.546142Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.545681Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.260657Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.260199Z",
+     "iopub.status.idle": "2021-12-02T06:59:29.261710Z",
+     "shell.execute_reply": "2021-12-02T06:59:29.262074Z"
     },
     "papermill": {
-     "duration": 0.048469,
-     "end_time": "2021-11-28T06:55:41.546239",
+     "duration": 0.047328,
+     "end_time": "2021-12-02T06:59:29.262188",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.497770",
+     "start_time": "2021-12-02T06:59:29.214860",
      "status": "completed"
     },
     "tags": []
@@ -324,16 +324,16 @@
    "id": "63638c0b-b436-48a9-93e0-db2adb939a61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:41.636454Z",
-     "iopub.status.busy": "2021-11-28T06:55:41.636010Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.641145Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.640689Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.350274Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.349833Z",
+     "iopub.status.idle": "2021-12-02T06:59:29.355055Z",
+     "shell.execute_reply": "2021-12-02T06:59:29.354611Z"
     },
     "papermill": {
-     "duration": 0.051177,
-     "end_time": "2021-11-28T06:55:41.641242",
+     "duration": 0.050418,
+     "end_time": "2021-12-02T06:59:29.355151",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.590065",
+     "start_time": "2021-12-02T06:59:29.304733",
      "status": "completed"
     },
     "tags": []
@@ -349,16 +349,16 @@
    "id": "808017ed-9a8a-4bf7-a3dd-42317a39ce8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:41.732521Z",
-     "iopub.status.busy": "2021-11-28T06:55:41.731995Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.734138Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.734507Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.444349Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.443759Z",
+     "iopub.status.idle": "2021-12-02T06:59:29.446135Z",
+     "shell.execute_reply": "2021-12-02T06:59:29.446508Z"
     },
     "papermill": {
-     "duration": 0.049079,
-     "end_time": "2021-11-28T06:55:41.734625",
+     "duration": 0.048957,
+     "end_time": "2021-12-02T06:59:29.446627",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.685546",
+     "start_time": "2021-12-02T06:59:29.397670",
      "status": "completed"
     },
     "tags": []
@@ -384,10 +384,10 @@
    "id": "716e4219-cad5-453b-8331-47d310689e03",
    "metadata": {
     "papermill": {
-     "duration": 0.044551,
-     "end_time": "2021-11-28T06:55:41.823750",
+     "duration": 0.042774,
+     "end_time": "2021-12-02T06:59:29.532908",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.779199",
+     "start_time": "2021-12-02T06:59:29.490134",
      "status": "completed"
     },
     "tags": []
@@ -402,16 +402,16 @@
    "id": "67807856-f337-4c6e-ae31-cd306577a314",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:41.915952Z",
-     "iopub.status.busy": "2021-11-28T06:55:41.915455Z",
-     "iopub.status.idle": "2021-11-28T06:55:41.917089Z",
-     "shell.execute_reply": "2021-11-28T06:55:41.917444Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.622372Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.621919Z",
+     "iopub.status.idle": "2021-12-02T06:59:29.624063Z",
+     "shell.execute_reply": "2021-12-02T06:59:29.623588Z"
     },
     "papermill": {
-     "duration": 0.049859,
-     "end_time": "2021-11-28T06:55:41.917559",
+     "duration": 0.048336,
+     "end_time": "2021-12-02T06:59:29.624160",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.867700",
+     "start_time": "2021-12-02T06:59:29.575824",
      "status": "completed"
     },
     "tags": []
@@ -429,16 +429,16 @@
    "id": "2965a695-5c0c-4e9e-8435-dcbfa610eb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:55:42.014050Z",
-     "iopub.status.busy": "2021-11-28T06:55:42.013593Z",
-     "iopub.status.idle": "2021-11-28T06:56:45.746657Z",
-     "shell.execute_reply": "2021-11-28T06:56:45.747042Z"
+     "iopub.execute_input": "2021-12-02T06:59:29.724187Z",
+     "iopub.status.busy": "2021-12-02T06:59:29.718062Z",
+     "iopub.status.idle": "2021-12-02T07:00:33.612706Z",
+     "shell.execute_reply": "2021-12-02T07:00:33.613056Z"
     },
     "papermill": {
-     "duration": 63.784362,
-     "end_time": "2021-11-28T06:56:45.747166",
+     "duration": 63.9455,
+     "end_time": "2021-12-02T07:00:33.613170",
      "exception": false,
-     "start_time": "2021-11-28T06:55:41.962804",
+     "start_time": "2021-12-02T06:59:29.667670",
      "status": "completed"
     },
     "tags": []
@@ -448,7 +448,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.93 s ± 6.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "3.95 s ± 6.19 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -463,16 +463,16 @@
    "id": "51c7a416-064a-4669-a09f-16f837d32475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:56:45.842959Z",
-     "iopub.status.busy": "2021-11-28T06:56:45.842462Z",
-     "iopub.status.idle": "2021-11-28T06:56:49.777790Z",
-     "shell.execute_reply": "2021-11-28T06:56:49.777337Z"
+     "iopub.execute_input": "2021-12-02T07:00:33.706095Z",
+     "iopub.status.busy": "2021-12-02T07:00:33.705592Z",
+     "iopub.status.idle": "2021-12-02T07:00:37.652175Z",
+     "shell.execute_reply": "2021-12-02T07:00:37.652548Z"
     },
     "papermill": {
-     "duration": 3.983657,
-     "end_time": "2021-11-28T06:56:49.777887",
+     "duration": 3.995521,
+     "end_time": "2021-12-02T07:00:37.652669",
      "exception": false,
-     "start_time": "2021-11-28T06:56:45.794230",
+     "start_time": "2021-12-02T07:00:33.657148",
      "status": "completed"
     },
     "tags": []
@@ -497,10 +497,10 @@
    "id": "025974ff-06d4-4d82-9b05-03f7a84d7211",
    "metadata": {
     "papermill": {
-     "duration": 0.045048,
-     "end_time": "2021-11-28T06:56:49.868779",
+     "duration": 0.044552,
+     "end_time": "2021-12-02T07:00:37.742342",
      "exception": false,
-     "start_time": "2021-11-28T06:56:49.823731",
+     "start_time": "2021-12-02T07:00:37.697790",
      "status": "completed"
     },
     "tags": []
@@ -515,16 +515,16 @@
    "id": "c20c4ecf-8060-495e-92b0-eb8e0d0dfbf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:56:49.963425Z",
-     "iopub.status.busy": "2021-11-28T06:56:49.962950Z",
-     "iopub.status.idle": "2021-11-28T06:56:49.964592Z",
-     "shell.execute_reply": "2021-11-28T06:56:49.964954Z"
+     "iopub.execute_input": "2021-12-02T07:00:37.836708Z",
+     "iopub.status.busy": "2021-12-02T07:00:37.836258Z",
+     "iopub.status.idle": "2021-12-02T07:00:37.838132Z",
+     "shell.execute_reply": "2021-12-02T07:00:37.837760Z"
     },
     "papermill": {
-     "duration": 0.0506,
-     "end_time": "2021-11-28T06:56:49.965070",
+     "duration": 0.050727,
+     "end_time": "2021-12-02T07:00:37.838231",
      "exception": false,
-     "start_time": "2021-11-28T06:56:49.914470",
+     "start_time": "2021-12-02T07:00:37.787504",
      "status": "completed"
     },
     "tags": []
@@ -542,16 +542,16 @@
    "id": "11259d8c-3bf3-4299-b47b-211556c3bc08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:56:50.061079Z",
-     "iopub.status.busy": "2021-11-28T06:56:50.060606Z",
-     "iopub.status.idle": "2021-11-28T06:56:59.182356Z",
-     "shell.execute_reply": "2021-11-28T06:56:59.181912Z"
+     "iopub.execute_input": "2021-12-02T07:00:37.934199Z",
+     "iopub.status.busy": "2021-12-02T07:00:37.933707Z",
+     "iopub.status.idle": "2021-12-02T07:00:47.152758Z",
+     "shell.execute_reply": "2021-12-02T07:00:47.153141Z"
     },
     "papermill": {
-     "duration": 9.171568,
-     "end_time": "2021-11-28T06:56:59.182452",
+     "duration": 9.268437,
+     "end_time": "2021-12-02T07:00:47.153255",
      "exception": false,
-     "start_time": "2021-11-28T06:56:50.010884",
+     "start_time": "2021-12-02T07:00:37.884818",
      "status": "completed"
     },
     "tags": []
@@ -561,7 +561,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "570 ms ± 1.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "576 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -576,16 +576,16 @@
    "id": "42d9e6e0-3c01-46e1-a409-52ff26cb78f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:56:59.279490Z",
-     "iopub.status.busy": "2021-11-28T06:56:59.278950Z",
-     "iopub.status.idle": "2021-11-28T06:56:59.854707Z",
-     "shell.execute_reply": "2021-11-28T06:56:59.854266Z"
+     "iopub.execute_input": "2021-12-02T07:00:47.250738Z",
+     "iopub.status.busy": "2021-12-02T07:00:47.250251Z",
+     "iopub.status.idle": "2021-12-02T07:00:47.827424Z",
+     "shell.execute_reply": "2021-12-02T07:00:47.827003Z"
     },
     "papermill": {
-     "duration": 0.625396,
-     "end_time": "2021-11-28T06:56:59.854801",
+     "duration": 0.627703,
+     "end_time": "2021-12-02T07:00:47.827521",
      "exception": false,
-     "start_time": "2021-11-28T06:56:59.229405",
+     "start_time": "2021-12-02T07:00:47.199818",
      "status": "completed"
     },
     "tags": []
@@ -611,10 +611,10 @@
    "id": "e2556204-1c10-4e01-8c6c-ea63ddb37530",
    "metadata": {
     "papermill": {
-     "duration": 0.046004,
-     "end_time": "2021-11-28T06:56:59.948170",
+     "duration": 0.046049,
+     "end_time": "2021-12-02T07:00:47.921401",
      "exception": false,
-     "start_time": "2021-11-28T06:56:59.902166",
+     "start_time": "2021-12-02T07:00:47.875352",
      "status": "completed"
     },
     "tags": []
@@ -646,14 +646,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 92.477182,
-   "end_time": "2021-11-28T06:57:00.401606",
+   "duration": 93.013986,
+   "end_time": "2021-12-02T07:00:48.374765",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/07-many_samples.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/07-many_samples.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T06:55:27.924424",
+   "start_time": "2021-12-02T06:59:15.360779",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/08-cm_many_genes.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/08-cm_many_genes.txt
@@ -1,56 +1,56 @@
-         888 function calls in 100.278 seconds
+         894 function calls in 103.180 seconds
 
    Ordered by: cumulative time
    List reduced from 95 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000  100.278  100.278 {built-in method builtins.exec}
-        1    0.000    0.000  100.278  100.278 <string>:1(<module>)
-        1    0.000    0.000  100.278  100.278 1750096170.py:1(func)
-        1    0.002    0.002  100.278  100.278 coef.py:252(cm)
-       26    0.000    0.000  100.275    3.857 threading.py:280(wait)
-       79  100.275    1.269  100.275    1.269 {method 'acquire' of '_thread.lock' objects}
-       20    0.000    0.000  100.274    5.014 _base.py:601(result_iterator)
-       18    0.000    0.000  100.274    5.571 _base.py:417(result)
-        2    0.000    0.000    0.001    0.001 _base.py:572(map)
-        2    0.000    0.000    0.001    0.001 _base.py:597(<listcomp>)
-       18    0.000    0.000    0.001    0.000 thread.py:155(submit)
+        1    0.000    0.000  103.180  103.180 {built-in method builtins.exec}
+        1    0.000    0.000  103.180  103.180 <string>:1(<module>)
+        1    0.000    0.000  103.180  103.180 1750096170.py:1(func)
+        1    0.001    0.001  103.180  103.180 coef.py:275(cm)
+       27    0.000    0.000  103.177    3.821 threading.py:280(wait)
+       81  103.177    1.274  103.177    1.274 {method 'acquire' of '_thread.lock' objects}
+       20    0.000    0.000  103.176    5.159 _base.py:601(result_iterator)
+       18    0.000    0.000  103.176    5.732 _base.py:417(result)
+        2    0.000    0.000    0.002    0.001 _base.py:572(map)
+        2    0.000    0.000    0.002    0.001 _base.py:597(<listcomp>)
+       18    0.000    0.000    0.002    0.000 thread.py:155(submit)
        18    0.000    0.000    0.001    0.000 thread.py:174(_adjust_thread_count)
         3    0.000    0.000    0.001    0.000 threading.py:873(start)
         3    0.000    0.000    0.001    0.000 threading.py:556(wait)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
         3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
        18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
-       18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
-        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
-        2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
-       22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
+        2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
        39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
-        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
-       14    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+        3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
         1    0.000    0.000    0.000    0.000 numeric.py:289(full)
+       18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
+       22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
+        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
         1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
-       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
-       18    0.000    0.000    0.000    0.000 {built-in method time.monotonic}
-        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
-        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
         1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
-        1    0.000    0.000    0.000    0.000 threading.py:398(__init__)
+       15    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+        1    0.000    0.000    0.000    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
+       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
         2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
-        1    0.000    0.000    0.000    0.000 {built-in method numpy.array}
+       15    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
+       12    0.000    0.000    0.000    0.000 threading.py:271(_is_owned)
+        3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
+       20    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
+       12    0.000    0.000    0.000    0.000 threading.py:265(_release_save)
+       21    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.lock' objects}
         1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
+        1    0.000    0.000    0.000    0.000 {built-in method numpy.asarray}
+       18    0.000    0.000    0.000    0.000 {built-in method time.monotonic}
         6    0.000    0.000    0.000    0.000 {method 'add' of 'set' objects}
         3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
        19    0.000    0.000    0.000    0.000 {method 'put' of '_queue.SimpleQueue' objects}
-       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
-        3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
+       32    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
         1    0.000    0.000    0.000    0.000 parallel.py:373(_launch_threads)
-       31    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
-       12    0.000    0.000    0.000    0.000 threading.py:271(_is_owned)
-       18    0.000    0.000    0.000    0.000 threading.py:82(RLock)
-       14    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
-       20    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
-       12    0.000    0.000    0.000    0.000 threading.py:268(_acquire_restore)
+        3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/08-many_genes.ipynb
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/08-many_genes.ipynb
@@ -5,10 +5,10 @@
    "id": "507e9319-381b-4934-987c-2958e7f6ace7",
    "metadata": {
     "papermill": {
-     "duration": 0.075202,
-     "end_time": "2021-11-28T06:57:04.217519",
+     "duration": 0.057991,
+     "end_time": "2021-12-02T07:00:52.229608",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.142317",
+     "start_time": "2021-12-02T07:00:52.171617",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "9a88f2a7-3773-459c-8fdc-c69c1b0bb338",
    "metadata": {
     "papermill": {
-     "duration": 0.0355,
-     "end_time": "2021-11-28T06:57:04.289317",
+     "duration": 0.038008,
+     "end_time": "2021-12-02T07:00:52.306389",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.253817",
+     "start_time": "2021-12-02T07:00:52.268381",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "61443ae0-70fe-42c4-adf2-76b8a7b22217",
    "metadata": {
     "papermill": {
-     "duration": 0.035064,
-     "end_time": "2021-11-28T06:57:04.360308",
+     "duration": 0.039559,
+     "end_time": "2021-12-02T07:00:52.385405",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.325244",
+     "start_time": "2021-12-02T07:00:52.345846",
      "status": "completed"
     },
     "tags": []
@@ -59,16 +59,16 @@
    "id": "9495a29b-3ba6-4a51-99b0-780fa5c1d9c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:04.439208Z",
-     "iopub.status.busy": "2021-11-28T06:57:04.438717Z",
-     "iopub.status.idle": "2021-11-28T06:57:04.442259Z",
-     "shell.execute_reply": "2021-11-28T06:57:04.441752Z"
+     "iopub.execute_input": "2021-12-02T07:00:52.468876Z",
+     "iopub.status.busy": "2021-12-02T07:00:52.468387Z",
+     "iopub.status.idle": "2021-12-02T07:00:52.471853Z",
+     "shell.execute_reply": "2021-12-02T07:00:52.471356Z"
     },
     "papermill": {
-     "duration": 0.045896,
-     "end_time": "2021-11-28T06:57:04.442362",
+     "duration": 0.048594,
+     "end_time": "2021-12-02T07:00:52.472047",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.396466",
+     "start_time": "2021-12-02T07:00:52.423453",
      "status": "completed"
     },
     "tags": []
@@ -91,10 +91,10 @@
    "id": "72de9f6f-dc00-435e-9dba-871db859a78a",
    "metadata": {
     "papermill": {
-     "duration": 0.036553,
-     "end_time": "2021-11-28T06:57:04.517070",
+     "duration": 0.03945,
+     "end_time": "2021-12-02T07:00:52.551173",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.480517",
+     "start_time": "2021-12-02T07:00:52.511723",
      "status": "completed"
     },
     "tags": []
@@ -109,16 +109,16 @@
    "id": "88d32361-f1b5-4cf0-9a2c-7ab927d14b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:04.593485Z",
-     "iopub.status.busy": "2021-11-28T06:57:04.593013Z",
-     "iopub.status.idle": "2021-11-28T06:57:05.178107Z",
-     "shell.execute_reply": "2021-11-28T06:57:05.176212Z"
+     "iopub.execute_input": "2021-12-02T07:00:52.632826Z",
+     "iopub.status.busy": "2021-12-02T07:00:52.632360Z",
+     "iopub.status.idle": "2021-12-02T07:00:53.220329Z",
+     "shell.execute_reply": "2021-12-02T07:00:53.218642Z"
     },
     "papermill": {
-     "duration": 0.625052,
-     "end_time": "2021-11-28T06:57:05.178471",
+     "duration": 0.630389,
+     "end_time": "2021-12-02T07:00:53.220710",
      "exception": false,
-     "start_time": "2021-11-28T06:57:04.553419",
+     "start_time": "2021-12-02T07:00:52.590321",
      "status": "completed"
     },
     "tags": []
@@ -128,7 +128,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code\n"
+      "/opt/code\r\n"
      ]
     }
    ],
@@ -142,16 +142,16 @@
    "id": "8a27da6e-cf59-4276-888b-57e98fd23ccf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:05.257159Z",
-     "iopub.status.busy": "2021-11-28T06:57:05.256698Z",
-     "iopub.status.idle": "2021-11-28T06:57:05.852763Z",
-     "shell.execute_reply": "2021-11-28T06:57:05.851166Z"
+     "iopub.execute_input": "2021-12-02T07:00:53.340097Z",
+     "iopub.status.busy": "2021-12-02T07:00:53.339585Z",
+     "iopub.status.idle": "2021-12-02T07:00:53.937065Z",
+     "shell.execute_reply": "2021-12-02T07:00:53.938600Z"
     },
     "papermill": {
-     "duration": 0.63701,
-     "end_time": "2021-11-28T06:57:05.853144",
+     "duration": 0.643753,
+     "end_time": "2021-12-02T07:00:53.939053",
      "exception": false,
-     "start_time": "2021-11-28T06:57:05.216134",
+     "start_time": "2021-12-02T07:00:53.295300",
      "status": "completed"
     },
     "tags": []
@@ -161,10 +161,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code/libs/clustermatch/__pycache__\n",
-      "/opt/code/libs/clustermatch/sklearn/__pycache__\n",
-      "/opt/code/libs/clustermatch/scipy/__pycache__\n",
-      "/opt/code/libs/clustermatch/pytorch/__pycache__\n"
+      "/opt/code/libs/clustermatch/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/sklearn/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/scipy/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/pytorch/__pycache__\r\n"
      ]
     }
    ],
@@ -178,16 +178,16 @@
    "id": "561480f7-c610-4f60-b40f-8100974ab4d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:05.935434Z",
-     "iopub.status.busy": "2021-11-28T06:57:05.934983Z",
-     "iopub.status.idle": "2021-11-28T06:57:06.539024Z",
-     "shell.execute_reply": "2021-11-28T06:57:06.540667Z"
+     "iopub.execute_input": "2021-12-02T07:00:54.060268Z",
+     "iopub.status.busy": "2021-12-02T07:00:54.059743Z",
+     "iopub.status.idle": "2021-12-02T07:00:54.669483Z",
+     "shell.execute_reply": "2021-12-02T07:00:54.668618Z"
     },
     "papermill": {
-     "duration": 0.648648,
-     "end_time": "2021-11-28T06:57:06.541122",
+     "duration": 0.65468,
+     "end_time": "2021-12-02T07:00:54.669657",
      "exception": false,
-     "start_time": "2021-11-28T06:57:05.892474",
+     "start_time": "2021-12-02T07:00:54.014977",
      "status": "completed"
     },
     "tags": []
@@ -203,16 +203,16 @@
    "id": "a5c90a17-c0ac-49f0-968d-ea9ea8710b00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:06.656861Z",
-     "iopub.status.busy": "2021-11-28T06:57:06.656386Z",
-     "iopub.status.idle": "2021-11-28T06:57:07.257927Z",
-     "shell.execute_reply": "2021-11-28T06:57:07.255976Z"
+     "iopub.execute_input": "2021-12-02T07:00:54.776327Z",
+     "iopub.status.busy": "2021-12-02T07:00:54.775812Z",
+     "iopub.status.idle": "2021-12-02T07:00:55.384690Z",
+     "shell.execute_reply": "2021-12-02T07:00:55.382916Z"
     },
     "papermill": {
-     "duration": 0.643913,
-     "end_time": "2021-11-28T06:57:07.258303",
+     "duration": 0.653733,
+     "end_time": "2021-12-02T07:00:55.385067",
      "exception": false,
-     "start_time": "2021-11-28T06:57:06.614390",
+     "start_time": "2021-12-02T07:00:54.731334",
      "status": "completed"
     },
     "tags": []
@@ -227,10 +227,10 @@
    "id": "145563a2-3e46-4f62-8191-7444a0b315bb",
    "metadata": {
     "papermill": {
-     "duration": 0.039381,
-     "end_time": "2021-11-28T06:57:07.336571",
+     "duration": 0.040542,
+     "end_time": "2021-12-02T07:00:55.467639",
      "exception": false,
-     "start_time": "2021-11-28T06:57:07.297190",
+     "start_time": "2021-12-02T07:00:55.427097",
      "status": "completed"
     },
     "tags": []
@@ -245,16 +245,16 @@
    "id": "bea3d48e-8823-403f-90f5-aea8a17b357c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:07.417034Z",
-     "iopub.status.busy": "2021-11-28T06:57:07.416562Z",
-     "iopub.status.idle": "2021-11-28T06:57:07.704197Z",
-     "shell.execute_reply": "2021-11-28T06:57:07.703787Z"
+     "iopub.execute_input": "2021-12-02T07:00:55.554840Z",
+     "iopub.status.busy": "2021-12-02T07:00:55.554389Z",
+     "iopub.status.idle": "2021-12-02T07:00:55.840706Z",
+     "shell.execute_reply": "2021-12-02T07:00:55.840224Z"
     },
     "papermill": {
-     "duration": 0.329536,
-     "end_time": "2021-11-28T06:57:07.704301",
+     "duration": 0.331927,
+     "end_time": "2021-12-02T07:00:55.840804",
      "exception": false,
-     "start_time": "2021-11-28T06:57:07.374765",
+     "start_time": "2021-12-02T07:00:55.508877",
      "status": "completed"
     },
     "tags": []
@@ -272,16 +272,16 @@
    "id": "df6b3793-930b-4c54-9f29-ecc47fc586fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:07.786239Z",
-     "iopub.status.busy": "2021-11-28T06:57:07.785773Z",
-     "iopub.status.idle": "2021-11-28T06:57:07.798482Z",
-     "shell.execute_reply": "2021-11-28T06:57:07.798852Z"
+     "iopub.execute_input": "2021-12-02T07:00:55.928318Z",
+     "iopub.status.busy": "2021-12-02T07:00:55.927777Z",
+     "iopub.status.idle": "2021-12-02T07:00:55.940644Z",
+     "shell.execute_reply": "2021-12-02T07:00:55.940182Z"
     },
     "papermill": {
-     "duration": 0.054732,
-     "end_time": "2021-11-28T06:57:07.798969",
+     "duration": 0.057579,
+     "end_time": "2021-12-02T07:00:55.940739",
      "exception": false,
-     "start_time": "2021-11-28T06:57:07.744237",
+     "start_time": "2021-12-02T07:00:55.883160",
      "status": "completed"
     },
     "tags": []
@@ -290,7 +290,7 @@
     {
      "data": {
       "text/plain": [
-       "0.25"
+       "0.15625"
       ]
      },
      "execution_count": 7,
@@ -308,10 +308,10 @@
    "id": "f8399ca8-265e-4e96-b582-54045cb2f9eb",
    "metadata": {
     "papermill": {
-     "duration": 0.039398,
-     "end_time": "2021-11-28T06:57:07.878786",
+     "duration": 0.041717,
+     "end_time": "2021-12-02T07:00:56.025508",
      "exception": false,
-     "start_time": "2021-11-28T06:57:07.839388",
+     "start_time": "2021-12-02T07:00:55.983791",
      "status": "completed"
     },
     "tags": []
@@ -326,16 +326,16 @@
    "id": "2316ffcd-a6e4-453f-bb52-779685c5c5bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:07.961673Z",
-     "iopub.status.busy": "2021-11-28T06:57:07.961226Z",
-     "iopub.status.idle": "2021-11-28T06:57:07.963353Z",
-     "shell.execute_reply": "2021-11-28T06:57:07.962934Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.112950Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.112415Z",
+     "iopub.status.idle": "2021-12-02T07:00:56.114405Z",
+     "shell.execute_reply": "2021-12-02T07:00:56.113947Z"
     },
     "papermill": {
-     "duration": 0.044236,
-     "end_time": "2021-11-28T06:57:07.963442",
+     "duration": 0.047201,
+     "end_time": "2021-12-02T07:00:56.114523",
      "exception": false,
-     "start_time": "2021-11-28T06:57:07.919206",
+     "start_time": "2021-12-02T07:00:56.067322",
      "status": "completed"
     },
     "tags": []
@@ -351,16 +351,16 @@
    "id": "b2f92fb1-113d-479b-8bbf-2be229e26e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:08.045420Z",
-     "iopub.status.busy": "2021-11-28T06:57:08.044982Z",
-     "iopub.status.idle": "2021-11-28T06:57:08.047115Z",
-     "shell.execute_reply": "2021-11-28T06:57:08.046671Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.211976Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.211481Z",
+     "iopub.status.idle": "2021-12-02T07:00:56.213546Z",
+     "shell.execute_reply": "2021-12-02T07:00:56.213092Z"
     },
     "papermill": {
-     "duration": 0.044381,
-     "end_time": "2021-11-28T06:57:08.047236",
+     "duration": 0.047504,
+     "end_time": "2021-12-02T07:00:56.213640",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.002855",
+     "start_time": "2021-12-02T07:00:56.166136",
      "status": "completed"
     },
     "tags": []
@@ -376,16 +376,16 @@
    "id": "63638c0b-b436-48a9-93e0-db2adb939a61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:08.129422Z",
-     "iopub.status.busy": "2021-11-28T06:57:08.128867Z",
-     "iopub.status.idle": "2021-11-28T06:57:08.131590Z",
-     "shell.execute_reply": "2021-11-28T06:57:08.131138Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.300065Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.299424Z",
+     "iopub.status.idle": "2021-12-02T07:00:56.302075Z",
+     "shell.execute_reply": "2021-12-02T07:00:56.301635Z"
     },
     "papermill": {
-     "duration": 0.045077,
-     "end_time": "2021-11-28T06:57:08.131685",
+     "duration": 0.0467,
+     "end_time": "2021-12-02T07:00:56.302168",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.086608",
+     "start_time": "2021-12-02T07:00:56.255468",
      "status": "completed"
     },
     "tags": []
@@ -401,16 +401,16 @@
    "id": "808017ed-9a8a-4bf7-a3dd-42317a39ce8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:08.214486Z",
-     "iopub.status.busy": "2021-11-28T06:57:08.213923Z",
-     "iopub.status.idle": "2021-11-28T06:57:08.216201Z",
-     "shell.execute_reply": "2021-11-28T06:57:08.216552Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.390662Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.390189Z",
+     "iopub.status.idle": "2021-12-02T07:00:56.392408Z",
+     "shell.execute_reply": "2021-12-02T07:00:56.392781Z"
     },
     "papermill": {
-     "duration": 0.045405,
-     "end_time": "2021-11-28T06:57:08.216661",
+     "duration": 0.048085,
+     "end_time": "2021-12-02T07:00:56.392900",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.171256",
+     "start_time": "2021-12-02T07:00:56.344815",
      "status": "completed"
     },
     "tags": []
@@ -436,10 +436,10 @@
    "id": "716e4219-cad5-453b-8331-47d310689e03",
    "metadata": {
     "papermill": {
-     "duration": 0.040458,
-     "end_time": "2021-11-28T06:57:08.297984",
+     "duration": 0.042717,
+     "end_time": "2021-12-02T07:00:56.479073",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.257526",
+     "start_time": "2021-12-02T07:00:56.436356",
      "status": "completed"
     },
     "tags": []
@@ -454,16 +454,16 @@
    "id": "67807856-f337-4c6e-ae31-cd306577a314",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:08.383428Z",
-     "iopub.status.busy": "2021-11-28T06:57:08.382958Z",
-     "iopub.status.idle": "2021-11-28T06:57:08.385116Z",
-     "shell.execute_reply": "2021-11-28T06:57:08.384664Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.568390Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.567934Z",
+     "iopub.status.idle": "2021-12-02T07:00:56.569820Z",
+     "shell.execute_reply": "2021-12-02T07:00:56.569369Z"
     },
     "papermill": {
-     "duration": 0.046013,
-     "end_time": "2021-11-28T06:57:08.385209",
+     "duration": 0.048485,
+     "end_time": "2021-12-02T07:00:56.569915",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.339196",
+     "start_time": "2021-12-02T07:00:56.521430",
      "status": "completed"
     },
     "tags": []
@@ -481,16 +481,16 @@
    "id": "2965a695-5c0c-4e9e-8435-dcbfa610eb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T06:57:08.472572Z",
-     "iopub.status.busy": "2021-11-28T06:57:08.471963Z",
-     "iopub.status.idle": "2021-11-28T07:23:45.973292Z",
-     "shell.execute_reply": "2021-11-28T07:23:45.973642Z"
+     "iopub.execute_input": "2021-12-02T07:00:56.661366Z",
+     "iopub.status.busy": "2021-12-02T07:00:56.660889Z",
+     "iopub.status.idle": "2021-12-02T07:28:29.010036Z",
+     "shell.execute_reply": "2021-12-02T07:28:29.010384Z"
     },
     "papermill": {
-     "duration": 1597.546919,
-     "end_time": "2021-11-28T07:23:45.973752",
+     "duration": 1652.397209,
+     "end_time": "2021-12-02T07:28:29.010497",
      "exception": false,
-     "start_time": "2021-11-28T06:57:08.426833",
+     "start_time": "2021-12-02T07:00:56.613288",
      "status": "completed"
     },
     "tags": []
@@ -500,7 +500,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1min 39s ± 643 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1min 43s ± 546 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -515,16 +515,16 @@
    "id": "51c7a416-064a-4669-a09f-16f837d32475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:23:46.062917Z",
-     "iopub.status.busy": "2021-11-28T07:23:46.062010Z",
-     "iopub.status.idle": "2021-11-28T07:25:26.383087Z",
-     "shell.execute_reply": "2021-11-28T07:25:26.383461Z"
+     "iopub.execute_input": "2021-12-02T07:28:29.101790Z",
+     "iopub.status.busy": "2021-12-02T07:28:29.101146Z",
+     "iopub.status.idle": "2021-12-02T07:30:12.329226Z",
+     "shell.execute_reply": "2021-12-02T07:30:12.329597Z"
     },
     "papermill": {
-     "duration": 100.368685,
-     "end_time": "2021-11-28T07:25:26.383573",
+     "duration": 103.275895,
+     "end_time": "2021-12-02T07:30:12.329709",
      "exception": false,
-     "start_time": "2021-11-28T07:23:46.014888",
+     "start_time": "2021-12-02T07:28:29.053814",
      "status": "completed"
     },
     "tags": []
@@ -549,10 +549,10 @@
    "id": "664b37eb-ead5-4b74-af40-41f1e257a5f3",
    "metadata": {
     "papermill": {
-     "duration": 0.042086,
-     "end_time": "2021-11-28T07:25:26.468138",
+     "duration": 0.043986,
+     "end_time": "2021-12-02T07:30:12.417650",
      "exception": false,
-     "start_time": "2021-11-28T07:25:26.426052",
+     "start_time": "2021-12-02T07:30:12.373664",
      "status": "completed"
     },
     "tags": []
@@ -565,20 +565,23 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c171afa1-7734-4ba5-b140-060d232c8f9c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.044279,
+     "end_time": "2021-12-02T07:30:12.506201",
+     "exception": false,
+     "start_time": "2021-12-02T07:30:12.461922",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -599,14 +602,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1703.796432,
-   "end_time": "2021-11-28T07:25:26.724149",
+   "duration": 1761.82284,
+   "end_time": "2021-12-02T07:30:12.762153",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/08-many_genes.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/08-many_genes.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T06:57:02.927717",
+   "start_time": "2021-12-02T07:00:50.939313",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-cm_many_samples-default_internal_n_clusters.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-cm_many_samples-default_internal_n_clusters.txt
@@ -1,56 +1,56 @@
-         950 function calls (946 primitive calls) in 5.010 seconds
+         928 function calls (924 primitive calls) in 4.986 seconds
 
    Ordered by: cumulative time
    List reduced from 96 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    5.010    5.010 {built-in method builtins.exec}
-        1    0.000    0.000    5.010    5.010 <string>:1(<module>)
-        1    0.000    0.000    5.010    5.010 1750096170.py:1(func)
-        1    0.001    0.001    5.010    5.010 coef.py:252(cm)
-       27    0.000    0.000    5.007    0.185 threading.py:280(wait)
-       81    5.007    0.062    5.007    0.062 {method 'acquire' of '_thread.lock' objects}
-       20    0.000    0.000    5.007    0.250 _base.py:601(result_iterator)
-       18    0.000    0.000    5.007    0.278 _base.py:417(result)
-        2    0.000    0.000    0.001    0.001 _base.py:572(map)
-        2    0.000    0.000    0.001    0.001 _base.py:597(<listcomp>)
+        1    0.000    0.000    4.986    4.986 {built-in method builtins.exec}
+        1    0.000    0.000    4.986    4.986 <string>:1(<module>)
+        1    0.000    0.000    4.986    4.986 1750096170.py:1(func)
+        1    0.001    0.001    4.986    4.986 coef.py:275(cm)
+       24    0.000    0.000    4.983    0.208 threading.py:280(wait)
+       75    4.983    0.066    4.983    0.066 {method 'acquire' of '_thread.lock' objects}
+       20    0.000    0.000    4.983    0.249 _base.py:601(result_iterator)
+       18    0.000    0.000    4.983    0.277 _base.py:417(result)
+        2    0.000    0.000    0.001    0.000 _base.py:572(map)
+        2    0.000    0.000    0.001    0.000 _base.py:597(<listcomp>)
        18    0.000    0.000    0.001    0.000 thread.py:155(submit)
        18    0.000    0.000    0.001    0.000 thread.py:174(_adjust_thread_count)
-        3    0.000    0.000    0.001    0.000 threading.py:873(start)
-        3    0.000    0.000    0.001    0.000 threading.py:556(wait)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
-       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
+        3    0.000    0.000    0.000    0.000 threading.py:873(start)
+        3    0.000    0.000    0.000    0.000 threading.py:556(wait)
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
         3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
-      6/2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
+       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
+      6/2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
         3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
+       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
        18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
-        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
        22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
         1    0.000    0.000    0.000    0.000 numeric.py:289(full)
-       39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
-        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
-        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
-       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
-        3    0.000    0.000    0.000    0.000 weakref.py:428(__setitem__)
+        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
         3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
-        6    0.000    0.000    0.000    0.000 threading.py:1338(current_thread)
-       15    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
-        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
-        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
-       19    0.000    0.000    0.000    0.000 {method 'put' of '_queue.SimpleQueue' objects}
+        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
+       15    0.000    0.000    0.000    0.000 {method 'release' of '_thread.lock' objects}
+       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
        28    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
-       32    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
-       15    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
-       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
-       12    0.000    0.000    0.000    0.000 threading.py:271(_is_owned)
-        1    0.000    0.000    0.000    0.000 parallel.py:373(_launch_threads)
-        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
-       18    0.000    0.000    0.000    0.000 threading.py:82(RLock)
         3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
+        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
+       12    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
+       12    0.000    0.000    0.000    0.000 threading.py:271(_is_owned)
         1    0.000    0.000    0.000    0.000 {built-in method numpy.array}
-       18    0.000    0.000    0.000    0.000 thread.py:41(__init__)
-        6    0.000    0.000    0.000    0.000 utils.py:99(chunker)
+        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+       21    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.lock' objects}
+        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
+       12    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+        1    0.000    0.000    0.000    0.000 {built-in method numpy.asarray}
+       12    0.000    0.000    0.000    0.000 {method '_is_owned' of '_thread.RLock' objects}
+       19    0.000    0.000    0.000    0.000 {method 'put' of '_queue.SimpleQueue' objects}
+        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
+       29    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       18    0.000    0.000    0.000    0.000 threading.py:82(RLock)
+       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
+        1    0.000    0.000    0.000    0.000 parallel.py:373(_launch_threads)
+        1    0.000    0.000    0.000    0.000 threading.py:398(__init__)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-cm_many_samples-less_internal_n_clusters.txt
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-cm_many_samples-less_internal_n_clusters.txt
@@ -1,56 +1,56 @@
-         945 function calls (941 primitive calls) in 0.497 seconds
+         945 function calls (941 primitive calls) in 0.508 seconds
 
    Ordered by: cumulative time
    List reduced from 96 to 50 due to restriction <50>
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.000    0.000    0.497    0.497 {built-in method builtins.exec}
-        1    0.000    0.000    0.497    0.497 <string>:1(<module>)
-        1    0.000    0.000    0.497    0.497 2695477961.py:1(func)
-        1    0.001    0.001    0.497    0.497 coef.py:252(cm)
-       27    0.000    0.000    0.495    0.018 threading.py:280(wait)
-       81    0.495    0.006    0.495    0.006 {method 'acquire' of '_thread.lock' objects}
-       20    0.000    0.000    0.495    0.025 _base.py:601(result_iterator)
-       18    0.000    0.000    0.495    0.027 _base.py:417(result)
+        1    0.000    0.000    0.508    0.508 {built-in method builtins.exec}
+        1    0.000    0.000    0.508    0.508 <string>:1(<module>)
+        1    0.000    0.000    0.508    0.508 2695477961.py:1(func)
+        1    0.001    0.001    0.508    0.508 coef.py:275(cm)
+       27    0.000    0.000    0.506    0.019 threading.py:280(wait)
+       81    0.506    0.006    0.506    0.006 {method 'acquire' of '_thread.lock' objects}
+       20    0.000    0.000    0.506    0.025 _base.py:601(result_iterator)
+       18    0.000    0.000    0.505    0.028 _base.py:417(result)
         2    0.000    0.000    0.001    0.001 _base.py:572(map)
         2    0.000    0.000    0.001    0.001 _base.py:597(<listcomp>)
        18    0.000    0.000    0.001    0.000 thread.py:155(submit)
        18    0.000    0.000    0.001    0.000 thread.py:174(_adjust_thread_count)
         3    0.000    0.000    0.001    0.000 threading.py:873(start)
         3    0.000    0.000    0.001    0.000 threading.py:556(wait)
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
-      6/2    0.000    0.000    0.000    0.000 coef.py:225(get_chunks)
-       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
         1    0.000    0.000    0.000    0.000 _base.py:635(__exit__)
         1    0.000    0.000    0.000    0.000 thread.py:210(shutdown)
         3    0.000    0.000    0.000    0.000 threading.py:1021(join)
         3    0.000    0.000    0.000    0.000 threading.py:1059(_wait_for_tstate_lock)
+       18    0.000    0.000    0.000    0.000 threading.py:404(acquire)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.zeros}
+      6/2    0.000    0.000    0.000    0.000 coef.py:233(get_chunks)
         3    0.000    0.000    0.000    0.000 {built-in method _thread.start_new_thread}
+        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
        18    0.000    0.000    0.000    0.000 _base.py:317(__init__)
        22    0.000    0.000    0.000    0.000 threading.py:228(__init__)
-        3    0.000    0.000    0.000    0.000 threading.py:795(__init__)
        39    0.000    0.000    0.000    0.000 threading.py:256(__enter__)
-       28    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
-       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
-        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
-        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
-       47    0.000    0.000    0.000    0.000 {built-in method builtins.len}
         3    0.000    0.000    0.000    0.000 threading.py:985(_stop)
-        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
-       18    0.000    0.000    0.000    0.000 _base.py:387(__get_result)
-       12    0.000    0.000    0.000    0.000 threading.py:268(_acquire_restore)
-        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
-       15    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
-        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
-       19    0.000    0.000    0.000    0.000 {method 'put' of '_queue.SimpleQueue' objects}
+       39    0.000    0.000    0.000    0.000 threading.py:259(__exit__)
+        1    0.000    0.000    0.000    0.000 coef.py:74(_get_range_n_clusters)
         3    0.000    0.000    0.000    0.000 threading.py:768(_maintain_shutdown_locks)
-       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
-        2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
+        1    0.000    0.000    0.000    0.000 {built-in method numpy.array}
+       15    0.000    0.000    0.000    0.000 {method '_acquire_restore' of '_thread.RLock' objects}
+        1    0.000    0.000    0.000    0.000 parallel.py:596(get_num_threads)
+        1    0.000    0.000    0.000    0.000 numeric.py:289(full)
+        1    0.000    0.000    0.000    0.000 thread.py:117(__init__)
+        3    0.000    0.000    0.000    0.000 {method 'difference_update' of 'set' objects}
+       19    0.000    0.000    0.000    0.000 {method 'put' of '_queue.SimpleQueue' objects}
+        3    0.000    0.000    0.000    0.000 threading.py:521(__init__)
        32    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       28    0.000    0.000    0.000    0.000 utils.py:107(<genexpr>)
+        2    0.000    0.000    0.000    0.000 {built-in method numpy.arange}
+       18    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.RLock' objects}
+       18    0.000    0.000    0.000    0.000 threading.py:82(RLock)
+       15    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
         1    0.000    0.000    0.000    0.000 parallel.py:373(_launch_threads)
        12    0.000    0.000    0.000    0.000 threading.py:271(_is_owned)
-       18    0.000    0.000    0.000    0.000 threading.py:82(RLock)
-        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
        18    0.000    0.000    0.000    0.000 thread.py:41(__init__)
-        6    0.000    0.000    0.000    0.000 utils.py:99(chunker)
-       15    0.000    0.000    0.000    0.000 {method '_release_save' of '_thread.RLock' objects}
+        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(copyto)
+       61    0.000    0.000    0.000    0.000 {method '__exit__' of '_thread.lock' objects}
+        6    0.000    0.000    0.000    0.000 threading.py:1338(current_thread)

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-many_samples.ipynb
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/09-many_samples.ipynb
@@ -5,10 +5,10 @@
    "id": "fd52facb-2470-4824-83d4-7c9fd042ecfb",
    "metadata": {
     "papermill": {
-     "duration": 0.080515,
-     "end_time": "2021-11-28T07:25:30.388913",
+     "duration": 0.084727,
+     "end_time": "2021-12-02T07:30:16.601946",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.308398",
+     "start_time": "2021-12-02T07:30:16.517219",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "7e0a6af6-c10e-45a5-9d8a-8849bf5ce82d",
    "metadata": {
     "papermill": {
-     "duration": 0.041338,
-     "end_time": "2021-11-28T07:25:30.471818",
+     "duration": 0.047223,
+     "end_time": "2021-12-02T07:30:16.695524",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.430480",
+     "start_time": "2021-12-02T07:30:16.648301",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "874ffd00-afe1-4b51-bb22-350cbd9479f1",
    "metadata": {
     "papermill": {
-     "duration": 0.042468,
-     "end_time": "2021-11-28T07:25:30.556021",
+     "duration": 0.046189,
+     "end_time": "2021-12-02T07:30:16.789311",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.513553",
+     "start_time": "2021-12-02T07:30:16.743122",
      "status": "completed"
     },
     "tags": []
@@ -57,16 +57,16 @@
    "id": "502fe9ff-d27d-43bd-aa37-73edf7ba4f24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:30.647374Z",
-     "iopub.status.busy": "2021-11-28T07:25:30.646903Z",
-     "iopub.status.idle": "2021-11-28T07:25:30.650267Z",
-     "shell.execute_reply": "2021-11-28T07:25:30.649760Z"
+     "iopub.execute_input": "2021-12-02T07:30:16.889633Z",
+     "iopub.status.busy": "2021-12-02T07:30:16.889169Z",
+     "iopub.status.idle": "2021-12-02T07:30:16.891738Z",
+     "shell.execute_reply": "2021-12-02T07:30:16.891249Z"
     },
     "papermill": {
-     "duration": 0.052682,
-     "end_time": "2021-11-28T07:25:30.650369",
+     "duration": 0.056388,
+     "end_time": "2021-12-02T07:30:16.891841",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.597687",
+     "start_time": "2021-12-02T07:30:16.835453",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "325cb06a-df7f-43e8-be3e-f704aaf015b0",
    "metadata": {
     "papermill": {
-     "duration": 0.043162,
-     "end_time": "2021-11-28T07:25:30.737999",
+     "duration": 0.046795,
+     "end_time": "2021-12-02T07:30:16.985901",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.694837",
+     "start_time": "2021-12-02T07:30:16.939106",
      "status": "completed"
     },
     "tags": []
@@ -107,16 +107,16 @@
    "id": "73f954a6-1776-4b92-bd0e-fc3caf5df081",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:30.825937Z",
-     "iopub.status.busy": "2021-11-28T07:25:30.825484Z",
-     "iopub.status.idle": "2021-11-28T07:25:31.412516Z",
-     "shell.execute_reply": "2021-11-28T07:25:31.410612Z"
+     "iopub.execute_input": "2021-12-02T07:30:17.083829Z",
+     "iopub.status.busy": "2021-12-02T07:30:17.083369Z",
+     "iopub.status.idle": "2021-12-02T07:30:17.680562Z",
+     "shell.execute_reply": "2021-12-02T07:30:17.678983Z"
     },
     "papermill": {
-     "duration": 0.632672,
-     "end_time": "2021-11-28T07:25:31.412892",
+     "duration": 0.64785,
+     "end_time": "2021-12-02T07:30:17.680989",
      "exception": false,
-     "start_time": "2021-11-28T07:25:30.780220",
+     "start_time": "2021-12-02T07:30:17.033139",
      "status": "completed"
     },
     "tags": []
@@ -126,7 +126,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code\n"
+      "/opt/code\r\n"
      ]
     }
    ],
@@ -140,16 +140,16 @@
    "id": "d17492bb-34fe-4c34-a693-419180ba068e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:31.506385Z",
-     "iopub.status.busy": "2021-11-28T07:25:31.505918Z",
-     "iopub.status.idle": "2021-11-28T07:25:32.105572Z",
-     "shell.execute_reply": "2021-11-28T07:25:32.103688Z"
+     "iopub.execute_input": "2021-12-02T07:30:17.818271Z",
+     "iopub.status.busy": "2021-12-02T07:30:17.817810Z",
+     "iopub.status.idle": "2021-12-02T07:30:18.423257Z",
+     "shell.execute_reply": "2021-12-02T07:30:18.421415Z"
     },
     "papermill": {
-     "duration": 0.647502,
-     "end_time": "2021-11-28T07:25:32.105943",
+     "duration": 0.658742,
+     "end_time": "2021-12-02T07:30:18.423634",
      "exception": false,
-     "start_time": "2021-11-28T07:25:31.458441",
+     "start_time": "2021-12-02T07:30:17.764892",
      "status": "completed"
     },
     "tags": []
@@ -159,10 +159,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/code/libs/clustermatch/__pycache__\n",
-      "/opt/code/libs/clustermatch/sklearn/__pycache__\n",
-      "/opt/code/libs/clustermatch/scipy/__pycache__\n",
-      "/opt/code/libs/clustermatch/pytorch/__pycache__\n"
+      "/opt/code/libs/clustermatch/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/sklearn/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/scipy/__pycache__\r\n",
+      "/opt/code/libs/clustermatch/pytorch/__pycache__\r\n"
      ]
     }
    ],
@@ -176,16 +176,16 @@
    "id": "5683e330-1782-43b3-bb78-255198f03620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:32.204814Z",
-     "iopub.status.busy": "2021-11-28T07:25:32.202700Z",
-     "iopub.status.idle": "2021-11-28T07:25:32.802661Z",
-     "shell.execute_reply": "2021-11-28T07:25:32.801048Z"
+     "iopub.execute_input": "2021-12-02T07:30:18.560159Z",
+     "iopub.status.busy": "2021-12-02T07:30:18.558236Z",
+     "iopub.status.idle": "2021-12-02T07:30:19.154403Z",
+     "shell.execute_reply": "2021-12-02T07:30:19.153648Z"
     },
     "papermill": {
-     "duration": 0.648339,
-     "end_time": "2021-11-28T07:25:32.803038",
+     "duration": 0.648936,
+     "end_time": "2021-12-02T07:30:19.154527",
      "exception": false,
-     "start_time": "2021-11-28T07:25:32.154699",
+     "start_time": "2021-12-02T07:30:18.505591",
      "status": "completed"
     },
     "tags": []
@@ -201,16 +201,16 @@
    "id": "5cf4ce29-d611-4fc8-8880-293c09e5ab9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:32.897473Z",
-     "iopub.status.busy": "2021-11-28T07:25:32.897007Z",
-     "iopub.status.idle": "2021-11-28T07:25:33.498772Z",
-     "shell.execute_reply": "2021-11-28T07:25:33.497069Z"
+     "iopub.execute_input": "2021-12-02T07:30:19.266540Z",
+     "iopub.status.busy": "2021-12-02T07:30:19.264349Z",
+     "iopub.status.idle": "2021-12-02T07:30:19.866750Z",
+     "shell.execute_reply": "2021-12-02T07:30:19.864873Z"
     },
     "papermill": {
-     "duration": 0.650009,
-     "end_time": "2021-11-28T07:25:33.499150",
+     "duration": 0.655452,
+     "end_time": "2021-12-02T07:30:19.867125",
      "exception": false,
-     "start_time": "2021-11-28T07:25:32.849141",
+     "start_time": "2021-12-02T07:30:19.211673",
      "status": "completed"
     },
     "tags": []
@@ -225,10 +225,10 @@
    "id": "35a04385-a901-4726-82a6-a01f16281efe",
    "metadata": {
     "papermill": {
-     "duration": 0.044987,
-     "end_time": "2021-11-28T07:25:33.590008",
+     "duration": 0.048405,
+     "end_time": "2021-12-02T07:30:19.965347",
      "exception": false,
-     "start_time": "2021-11-28T07:25:33.545021",
+     "start_time": "2021-12-02T07:30:19.916942",
      "status": "completed"
     },
     "tags": []
@@ -243,16 +243,16 @@
    "id": "a75c4496-d379-4668-905d-0e9136981f0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:33.683281Z",
-     "iopub.status.busy": "2021-11-28T07:25:33.682835Z",
-     "iopub.status.idle": "2021-11-28T07:25:33.971741Z",
-     "shell.execute_reply": "2021-11-28T07:25:33.972117Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.065281Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.064813Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.362955Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.362555Z"
     },
     "papermill": {
-     "duration": 0.337701,
-     "end_time": "2021-11-28T07:25:33.972247",
+     "duration": 0.349656,
+     "end_time": "2021-12-02T07:30:20.363071",
      "exception": false,
-     "start_time": "2021-11-28T07:25:33.634546",
+     "start_time": "2021-12-02T07:30:20.013415",
      "status": "completed"
     },
     "tags": []
@@ -270,16 +270,16 @@
    "id": "1a58ccf8-1bf5-4177-9b06-944a0d57655a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.067109Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.066647Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.078948Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.079319Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.465814Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.465341Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.477563Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.477109Z"
     },
     "papermill": {
-     "duration": 0.061435,
-     "end_time": "2021-11-28T07:25:34.079440",
+     "duration": 0.064264,
+     "end_time": "2021-12-02T07:30:20.477659",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.018005",
+     "start_time": "2021-12-02T07:30:20.413395",
      "status": "completed"
     },
     "tags": []
@@ -288,7 +288,7 @@
     {
      "data": {
       "text/plain": [
-       "0.0"
+       "0.28"
       ]
      },
      "execution_count": 7,
@@ -306,10 +306,10 @@
    "id": "2c92a1ad-2fc9-4a16-a5f8-fce685246996",
    "metadata": {
     "papermill": {
-     "duration": 0.045019,
-     "end_time": "2021-11-28T07:25:34.172385",
+     "duration": 0.049251,
+     "end_time": "2021-12-02T07:30:20.576876",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.127366",
+     "start_time": "2021-12-02T07:30:20.527625",
      "status": "completed"
     },
     "tags": []
@@ -324,16 +324,16 @@
    "id": "2316ffcd-a6e4-453f-bb52-779685c5c5bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.265897Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.265436Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.267573Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.267132Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.679049Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.678606Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.680198Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.680560Z"
     },
     "papermill": {
-     "duration": 0.05052,
-     "end_time": "2021-11-28T07:25:34.267666",
+     "duration": 0.054426,
+     "end_time": "2021-12-02T07:30:20.680674",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.217146",
+     "start_time": "2021-12-02T07:30:20.626248",
      "status": "completed"
     },
     "tags": []
@@ -349,16 +349,16 @@
    "id": "b2f92fb1-113d-479b-8bbf-2be229e26e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.362573Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.362128Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.363627Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.363999Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.784325Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.783711Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.786877Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.786443Z"
     },
     "papermill": {
-     "duration": 0.050936,
-     "end_time": "2021-11-28T07:25:34.364117",
+     "duration": 0.055871,
+     "end_time": "2021-12-02T07:30:20.786970",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.313181",
+     "start_time": "2021-12-02T07:30:20.731099",
      "status": "completed"
     },
     "tags": []
@@ -374,16 +374,16 @@
    "id": "63638c0b-b436-48a9-93e0-db2adb939a61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.458891Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.458459Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.466243Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.465009Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.889583Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.889148Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.894209Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.893773Z"
     },
     "papermill": {
-     "duration": 0.056345,
-     "end_time": "2021-11-28T07:25:34.466466",
+     "duration": 0.057292,
+     "end_time": "2021-12-02T07:30:20.894304",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.410121",
+     "start_time": "2021-12-02T07:30:20.837012",
      "status": "completed"
     },
     "tags": []
@@ -399,16 +399,16 @@
    "id": "808017ed-9a8a-4bf7-a3dd-42317a39ce8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.584447Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.583930Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.586058Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.586413Z"
+     "iopub.execute_input": "2021-12-02T07:30:20.997120Z",
+     "iopub.status.busy": "2021-12-02T07:30:20.996590Z",
+     "iopub.status.idle": "2021-12-02T07:30:20.999375Z",
+     "shell.execute_reply": "2021-12-02T07:30:20.998933Z"
     },
     "papermill": {
-     "duration": 0.052389,
-     "end_time": "2021-11-28T07:25:34.586529",
+     "duration": 0.055432,
+     "end_time": "2021-12-02T07:30:20.999471",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.534140",
+     "start_time": "2021-12-02T07:30:20.944039",
      "status": "completed"
     },
     "tags": []
@@ -434,10 +434,10 @@
    "id": "716e4219-cad5-453b-8331-47d310689e03",
    "metadata": {
     "papermill": {
-     "duration": 0.0466,
-     "end_time": "2021-11-28T07:25:34.680364",
+     "duration": 0.049859,
+     "end_time": "2021-12-02T07:30:21.100960",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.633764",
+     "start_time": "2021-12-02T07:30:21.051101",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "67807856-f337-4c6e-ae31-cd306577a314",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.777519Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.777073Z",
-     "iopub.status.idle": "2021-11-28T07:25:34.779173Z",
-     "shell.execute_reply": "2021-11-28T07:25:34.778725Z"
+     "iopub.execute_input": "2021-12-02T07:30:21.214530Z",
+     "iopub.status.busy": "2021-12-02T07:30:21.214082Z",
+     "iopub.status.idle": "2021-12-02T07:30:21.215531Z",
+     "shell.execute_reply": "2021-12-02T07:30:21.215894Z"
     },
     "papermill": {
-     "duration": 0.052049,
-     "end_time": "2021-11-28T07:25:34.779266",
+     "duration": 0.059587,
+     "end_time": "2021-12-02T07:30:21.216025",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.727217",
+     "start_time": "2021-12-02T07:30:21.156438",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +479,16 @@
    "id": "2965a695-5c0c-4e9e-8435-dcbfa610eb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:25:34.879351Z",
-     "iopub.status.busy": "2021-11-28T07:25:34.878881Z",
-     "iopub.status.idle": "2021-11-28T07:26:54.769462Z",
-     "shell.execute_reply": "2021-11-28T07:26:54.769806Z"
+     "iopub.execute_input": "2021-12-02T07:30:21.323159Z",
+     "iopub.status.busy": "2021-12-02T07:30:21.322335Z",
+     "iopub.status.idle": "2021-12-02T07:31:41.858121Z",
+     "shell.execute_reply": "2021-12-02T07:31:41.858466Z"
     },
     "papermill": {
-     "duration": 79.94265,
-     "end_time": "2021-11-28T07:26:54.769919",
+     "duration": 80.591387,
+     "end_time": "2021-12-02T07:31:41.858578",
      "exception": false,
-     "start_time": "2021-11-28T07:25:34.827269",
+     "start_time": "2021-12-02T07:30:21.267191",
      "status": "completed"
     },
     "tags": []
@@ -498,7 +498,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 s ± 37.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "5.04 s ± 33.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -513,16 +513,16 @@
    "id": "51c7a416-064a-4669-a09f-16f837d32475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:26:54.869309Z",
-     "iopub.status.busy": "2021-11-28T07:26:54.868827Z",
-     "iopub.status.idle": "2021-11-28T07:26:59.882880Z",
-     "shell.execute_reply": "2021-11-28T07:26:59.882426Z"
+     "iopub.execute_input": "2021-12-02T07:31:41.966227Z",
+     "iopub.status.busy": "2021-12-02T07:31:41.965665Z",
+     "iopub.status.idle": "2021-12-02T07:31:46.955692Z",
+     "shell.execute_reply": "2021-12-02T07:31:46.956135Z"
     },
     "papermill": {
-     "duration": 5.065953,
-     "end_time": "2021-11-28T07:26:59.882978",
+     "duration": 5.04616,
+     "end_time": "2021-12-02T07:31:46.956254",
      "exception": false,
-     "start_time": "2021-11-28T07:26:54.817025",
+     "start_time": "2021-12-02T07:31:41.910094",
      "status": "completed"
     },
     "tags": []
@@ -545,7 +545,16 @@
   {
    "cell_type": "markdown",
    "id": "cd74d8b8-517c-42cf-9dbf-27474b2c3822",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.052197,
+     "end_time": "2021-12-02T07:31:47.061650",
+     "exception": false,
+     "start_time": "2021-12-02T07:31:47.009453",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "These results are just slightly worse than the numba-compiled version (notebook `07`)."
    ]
@@ -555,10 +564,10 @@
    "id": "025974ff-06d4-4d82-9b05-03f7a84d7211",
    "metadata": {
     "papermill": {
-     "duration": 0.048089,
-     "end_time": "2021-11-28T07:26:59.980623",
+     "duration": 0.052169,
+     "end_time": "2021-12-02T07:31:47.165707",
      "exception": false,
-     "start_time": "2021-11-28T07:26:59.932534",
+     "start_time": "2021-12-02T07:31:47.113538",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +582,16 @@
    "id": "c20c4ecf-8060-495e-92b0-eb8e0d0dfbf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:27:00.083119Z",
-     "iopub.status.busy": "2021-11-28T07:27:00.082620Z",
-     "iopub.status.idle": "2021-11-28T07:27:00.084165Z",
-     "shell.execute_reply": "2021-11-28T07:27:00.084520Z"
+     "iopub.execute_input": "2021-12-02T07:31:47.273226Z",
+     "iopub.status.busy": "2021-12-02T07:31:47.272787Z",
+     "iopub.status.idle": "2021-12-02T07:31:47.274928Z",
+     "shell.execute_reply": "2021-12-02T07:31:47.274490Z"
     },
     "papermill": {
-     "duration": 0.054556,
-     "end_time": "2021-11-28T07:27:00.084634",
+     "duration": 0.057719,
+     "end_time": "2021-12-02T07:31:47.275023",
      "exception": false,
-     "start_time": "2021-11-28T07:27:00.030078",
+     "start_time": "2021-12-02T07:31:47.217304",
      "status": "completed"
     },
     "tags": []
@@ -600,16 +609,16 @@
    "id": "11259d8c-3bf3-4299-b47b-211556c3bc08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:27:00.187093Z",
-     "iopub.status.busy": "2021-11-28T07:27:00.186612Z",
-     "iopub.status.idle": "2021-11-28T07:27:08.215528Z",
-     "shell.execute_reply": "2021-11-28T07:27:08.215081Z"
+     "iopub.execute_input": "2021-12-02T07:31:47.384181Z",
+     "iopub.status.busy": "2021-12-02T07:31:47.383683Z",
+     "iopub.status.idle": "2021-12-02T07:31:55.526921Z",
+     "shell.execute_reply": "2021-12-02T07:31:55.527582Z"
     },
     "papermill": {
-     "duration": 8.081509,
-     "end_time": "2021-11-28T07:27:08.215623",
+     "duration": 8.200213,
+     "end_time": "2021-12-02T07:31:55.527738",
      "exception": false,
-     "start_time": "2021-11-28T07:27:00.134114",
+     "start_time": "2021-12-02T07:31:47.327525",
      "status": "completed"
     },
     "tags": []
@@ -619,7 +628,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "504 ms ± 4.11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "500 ms ± 3.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -634,16 +643,16 @@
    "id": "42d9e6e0-3c01-46e1-a409-52ff26cb78f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-11-28T07:27:08.321699Z",
-     "iopub.status.busy": "2021-11-28T07:27:08.321223Z",
-     "iopub.status.idle": "2021-11-28T07:27:08.821422Z",
-     "shell.execute_reply": "2021-11-28T07:27:08.821797Z"
+     "iopub.execute_input": "2021-12-02T07:31:55.643612Z",
+     "iopub.status.busy": "2021-12-02T07:31:55.643116Z",
+     "iopub.status.idle": "2021-12-02T07:31:56.153828Z",
+     "shell.execute_reply": "2021-12-02T07:31:56.154221Z"
     },
     "papermill": {
-     "duration": 0.554356,
-     "end_time": "2021-11-28T07:27:08.821916",
+     "duration": 0.567955,
+     "end_time": "2021-12-02T07:31:56.154340",
      "exception": false,
-     "start_time": "2021-11-28T07:27:08.267560",
+     "start_time": "2021-12-02T07:31:55.586385",
      "status": "completed"
     },
     "tags": []
@@ -666,7 +675,16 @@
   {
    "cell_type": "markdown",
    "id": "ba154ea5-5301-4fd4-8fc7-71534435a2a5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.052863,
+     "end_time": "2021-12-02T07:31:56.261630",
+     "exception": false,
+     "start_time": "2021-12-02T07:31:56.208767",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "These results are slightly better than the numba-compiled version (notebook `07`), which is surprising. In the future, it would be interesting to disable threading here to get accurate profiling results to debug this issue."
    ]
@@ -677,10 +695,10 @@
    "id": "e2556204-1c10-4e01-8c6c-ea63ddb37530",
    "metadata": {
     "papermill": {
-     "duration": 0.049886,
-     "end_time": "2021-11-28T07:27:08.922064",
+     "duration": 0.05275,
+     "end_time": "2021-12-02T07:31:56.367603",
      "exception": false,
-     "start_time": "2021-11-28T07:27:08.872178",
+     "start_time": "2021-12-02T07:31:56.314853",
      "status": "completed"
     },
     "tags": []
@@ -691,13 +709,7 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
-   "text_representation": {
-    "extension": ".py",
-    "format_name": "percent",
-    "format_version": "1.3",
-    "jupytext_version": "1.11.5"
-   }
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -718,14 +730,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 100.015769,
-   "end_time": "2021-11-28T07:27:09.181798",
+   "duration": 101.331077,
+   "end_time": "2021-12-02T07:31:56.627731",
    "environment_variables": {},
    "exception": null,
    "input_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/09-many_samples.ipynb",
    "output_path": "nbs/others/05_clustermatch_profiling/11_cm_optimized/09-many_samples.run.ipynb",
    "parameters": {},
-   "start_time": "2021-11-28T07:25:29.166029",
+   "start_time": "2021-12-02T07:30:15.296654",
    "version": "2.3.3"
   }
  },

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/py/08-many_genes.py
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/py/08-many_genes.py
@@ -90,4 +90,4 @@ func()
 # %% [markdown] tags=[]
 # **CONCLUSIONS:** compared with notebook `06` (which has 500 rows (`n_genes`) instead of 50 here), this one would have taken 2.80 hours for 500 rows based on this results. Whereas the numba-compiled version took ~7 minutes.
 
-# %%
+# %% tags=[]

--- a/nbs/others/05_clustermatch_profiling/11_cm_optimized/py/09-many_samples.py
+++ b/nbs/others/05_clustermatch_profiling/11_cm_optimized/py/09-many_samples.py
@@ -86,7 +86,7 @@ func()
 func()
 
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # These results are just slightly worse than the numba-compiled version (notebook `07`).
 
 # %% [markdown] tags=[]
@@ -106,7 +106,7 @@ func()
 # %%prun -s cumulative -l 50 -T 09-cm_many_samples-less_internal_n_clusters.txt
 func()
 
-# %% [markdown]
+# %% [markdown] tags=[]
 # These results are slightly better than the numba-compiled version (notebook `07`), which is surprising. In the future, it would be interesting to disable threading here to get accurate profiling results to debug this issue.
 
 # %% tags=[]

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -1053,3 +1053,51 @@ def test_get_chunks_iterable():
     assert len(cs) == 10
     assert set(map(len, cs)) == {1}
     assert {x for i in cs for x in i} == set(iterable)
+
+
+def test_cm_data_is_binary_evenly_distributed():
+    # Prepare
+    np.random.seed(0)
+
+    # two features with a quadratic relationship
+    feature0 = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
+    feature1 = np.random.rand(10)
+
+    # Run
+    cm_value, max_parts, parts = cm(
+        feature0, feature1, internal_n_clusters=[2], return_parts=True
+    )
+
+    # Validate
+    assert cm_value < 0.05
+
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].shape == (1, 10)
+
+    # the partition should separate true from false values in data
+    assert ari(parts[0][0], feature0) == 1.0
+
+
+def test_cm_data_is_binary_not_evenly_distributed():
+    # Prepare
+    np.random.seed(0)
+
+    # two features with a quadratic relationship
+    feature0 = np.array([1, 1, 1, 1, 1, 1, 1, 1, 0, 0])
+    feature1 = np.random.rand(10)
+
+    # Run
+    cm_value, max_parts, parts = cm(
+        feature0, feature1, internal_n_clusters=[2], return_parts=True
+    )
+
+    # Validate
+    assert cm_value < 0.05
+
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].shape == (1, 10)
+
+    # the partition should separate true from false values in data
+    assert ari(parts[0][0], feature0) == 1.0

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -783,7 +783,7 @@ def test_cm_return_parts_quadratic():
     )
 
     # Validate
-    assert cm_value.round(2) == 0.59
+    assert cm_value.round(2) == 0.31
 
     assert parts is not None
     assert len(parts) == 2

--- a/tests/test_scipy_stats.py
+++ b/tests/test_scipy_stats.py
@@ -7,7 +7,7 @@ from clustermatch.scipy.stats import rank
 def test_rank_no_duplicates():
     data = np.array([0, 10, 1, 5, 7, 8, -5, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -16,7 +16,7 @@ def test_rank_no_duplicates():
 def test_rank_one_duplicate_group():
     data = np.array([0, 10, 1, 5, 7, 8, 1, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -25,7 +25,7 @@ def test_rank_one_duplicate_group():
 def test_rank_one_duplicate_group_with_more_elements():
     data = np.array([0, 10, 1, 1, 7, 8, 1, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -34,7 +34,7 @@ def test_rank_one_duplicate_group_with_more_elements():
 def test_rank_one_duplicate_group_at_beginning():
     data = np.array([0, 0, 1, -10, 7, 8, 9.4, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -43,7 +43,7 @@ def test_rank_one_duplicate_group_at_beginning():
 def test_rank_one_duplicate_group_at_beginning_with_more_elements():
     data = np.array([0.13, 0.13, 0.13, 1, -10, 7, 8, 9.4, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -52,7 +52,7 @@ def test_rank_one_duplicate_group_at_beginning_with_more_elements():
 def test_rank_one_duplicate_group_at_beginning_are_smallest():
     data = np.array([0, 10, 1.5, -99.5, -99.5, -99.5, 5, 7, 8, -5, -2])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -61,7 +61,7 @@ def test_rank_one_duplicate_group_at_beginning_are_smallest():
 def test_rank_one_duplicate_group_at_end():
     data = np.array([0, 1, -10, 7, 8, 9.4, -2.5, -2.5])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -70,7 +70,7 @@ def test_rank_one_duplicate_group_at_end():
 def test_rank_one_duplicate_group_at_end_with_more_elements():
     data = np.array([0, 1, -10, 7, 8, 9.4, -12.5, -12.5, -12.5])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -79,7 +79,7 @@ def test_rank_one_duplicate_group_at_end_with_more_elements():
 def test_rank_one_duplicate_group_at_end_is_the_largest():
     data = np.array([0, 1, -10, 7, 8, 9.4, 120.5, 120.5, 120.5])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)
@@ -88,7 +88,7 @@ def test_rank_one_duplicate_group_at_end_is_the_largest():
 def test_rank_all_are_duplicates():
     data = np.array([1.5, 1.5, 1.5, 1.5])
 
-    expected_ranks = stats.rankdata(data, "dense")
+    expected_ranks = stats.rankdata(data, "average")
     observed_ranks = rank(data)
 
     np.testing.assert_array_equal(observed_ranks, expected_ranks)


### PR DESCRIPTION
This is a small PR that fixes an issue I found with the Clutermatch coefficient in very rare cases. It basically gives a different score than the original implementation because of the changes introduced to optimize the `rank` function.

Only four `.py` files under `libs/` and `tests/` really need review, the rest are profiling results that were run again and are consistent with previous results.